### PR TITLE
Replace JSR 305 annotations with Checker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
         <java.version>11</java.version>
 
         <apache.commons.version>3.12.0</apache.commons.version>
+        <checker-qual.version>3.34.0</checker-qual.version>
         <commonscodec.version>1.15</commonscodec.version>
-        <findbugs.version>3.0.2</findbugs.version>
         <guava.version>31.1-jre</guava.version>
         <immutables.version>2.9.3</immutables.version>
         <jackson.version>2.15.1</jackson.version>
@@ -99,12 +99,10 @@
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
-        <!-- this dependency is required to avoid javax.annotation.CheckReturnValue,
-         see https://github.com/google/guava/issues/2450 for more details -->
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>${findbugs.version}</version>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>3.34.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/com/orbitz/consul/model/agent/Agent.java
+++ b/src/main/java/com/orbitz/consul/model/agent/Agent.java
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.immutables.value.Value;
 
-import java.util.Map;
-import javax.annotation.Nullable;
 import java.util.Map;
 
 @Value.Immutable

--- a/src/main/java/com/orbitz/consul/util/failover/strategy/ConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/ConsulFailoverStrategy.java
@@ -1,26 +1,26 @@
 package com.orbitz.consul.util.failover.strategy;
 
-import java.util.Optional;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import java.util.Optional;
 
 import okhttp3.Request;
 import okhttp3.Response;
 
 public interface ConsulFailoverStrategy {
 
-	
+
 	/**
 	 * Computes the next failover stage for the consul failover strategy. This allows the end user to customize the way
 	 * and methods by which additional failover targets may be selected.
 	 * @param previousRequest The last request to go out the door.
-	 * @param previousResponse The response that returned when previousRequest was completed. 
+	 * @param previousResponse The response that returned when previousRequest was completed.
 	 * @return An optional failover request. This may return an empty optional, signaling that the request should be aborted
 	 */
-	@Nullable
-	public Optional<Request> computeNextStage(@Nonnull Request previousRequest, @Nullable Response previousResponse);
-	
+	@NonNull
+	public Optional<Request> computeNextStage(@NonNull Request previousRequest, @Nullable Response previousResponse);
+
 	/**
 	 * Determines if there is a viable candidate for the next request. This lets us short circuit the first attempted request
 	 * (such as when we know with certainty that a host should not be available) without interfering with the consul client too
@@ -28,14 +28,14 @@ public interface ConsulFailoverStrategy {
 	 * @param current The current inflight request.
 	 * @return A boolean representing if there is another possible request candidate available.
 	 */
-	public boolean isRequestViable(@Nonnull Request current);
-	
+	public boolean isRequestViable(@NonNull Request current);
+
 	/**
 	 * Marks the specified request as a failed URL (in case of exceptions and other events that could cause
 	 * us to never get a response. This avoids infinite loops where the strategy can never be made aware that the request
 	 * has failed.
 	 * @param current The current request object representing a request that failed
 	 */
-	public void markRequestFailed(@Nonnull Request current);
-	
+	public void markRequestFailed(@NonNull Request current);
+
 }


### PR DESCRIPTION
* Remove explicit JSR 305 dependency
* Add checker-qual dependency
* Replace javax.annotation annotations with Checker ones (the only ones in use were Nonnull and Nullable)
* Change ConsulFailoverStrategy#computeNextStage to use NonNull annotation instead of Nullable, since a method that returns Optional should NOT EVER return null. Verified as best as I could that the code never returns null.
* Remove redundant java.util.Map import from Agent

Closes #10