### PR TITLE
Sonar: don't compare "dissimilar" types

### DIFF
--- a/src/itest/java/com/orbitz/consul/KeyValueITest.java
+++ b/src/itest/java/com/orbitz/consul/KeyValueITest.java
@@ -2,8 +2,8 @@ package com.orbitz.consul;
 
 import java.nio.charset.Charset;
 import java.util.Optional;
+import java.util.Set;
 
-import com.google.common.collect.ImmutableSet;
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.kv.ImmutableOperation;
@@ -162,7 +162,7 @@ public class KeyValueITest extends BaseIntegrationTest {
 
         assertTrue(keyValueClient.putValue(key, value));
         assertTrue(keyValueClient.putValue(key2, value2));
-        assertEquals(ImmutableSet.of(value, value2), new HashSet<>(keyValueClient.getValuesAsString(key)));
+        assertEquals(Set.of(value, value2), new HashSet<>(keyValueClient.getValuesAsString(key)));
     }
 
     @Test
@@ -175,7 +175,7 @@ public class KeyValueITest extends BaseIntegrationTest {
 
         assertTrue(keyValueClient.putValue(key, value, TEST_CHARSET));
         assertTrue(keyValueClient.putValue(key2, value2, TEST_CHARSET));
-        assertEquals(ImmutableSet.of(value, value2), new HashSet<>(keyValueClient.getValuesAsString(key, TEST_CHARSET)));
+        assertEquals(Set.of(value, value2), new HashSet<>(keyValueClient.getValuesAsString(key, TEST_CHARSET)));
     }
 
     @Test


### PR DESCRIPTION
This is sort of a false positive, since Sonar is considering ImmutableSet and HashSet as "dissimilar" when in reality they both implement Set and the equals comparison
works correctly. However, decided to replace ImmutableSet with Set.of anyway, since that JDK method creates an unmodifiable Set.

Sonar java:S5845:
Assertions comparing incompatible types should not be made

Part of #61