### PR TITLE
Sonar: fix assertion argument order in tests

### DIFF
--- a/src/itest/java/com/orbitz/consul/AgentITest.java
+++ b/src/itest/java/com/orbitz/consul/AgentITest.java
@@ -489,7 +489,7 @@ public class AgentITest extends BaseIntegrationTest {
             HealthCheck check = client.agentClient().getChecks().get(checkId);
 
             assertEquals(check.getCheckId(), checkId);
-            assertEquals(check.getName(), "test-validate");
+            assertEquals("test-validate", check.getName());
         }
         finally {
             client.agentClient().deregisterCheck(checkId);
@@ -506,7 +506,7 @@ public class AgentITest extends BaseIntegrationTest {
             HealthCheck check = client.agentClient().getChecks().get(checkId);
 
             assertEquals(check.getCheckId(), checkId);
-            assertEquals(check.getName(), "test-validate");
+            assertEquals("test-validate", check.getName());
         }
         finally {
             client.agentClient().deregisterCheck(checkId);
@@ -522,7 +522,7 @@ public class AgentITest extends BaseIntegrationTest {
             HealthCheck check = client.agentClient().getChecks().get(checkId);
 
             assertEquals(check.getCheckId(), checkId);
-            assertEquals(check.getName(), "test-validate");
+            assertEquals("test-validate", check.getName());
         }
         finally {
             client.agentClient().deregisterCheck(checkId);

--- a/src/itest/java/com/orbitz/consul/cache/ServiceHealthCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/ServiceHealthCacheITest.java
@@ -71,7 +71,7 @@ public class ServiceHealthCacheITest extends BaseIntegrationTest {
                     .orElseThrow(() -> new RuntimeException("Cannot find service key 2 from serviceHealthCache"));
 
             ImmutableMap<ServiceHealthKey, ServiceHealth> healthMap = svHealth.getMap();
-            assertEquals(healthMap.size(), 2);
+            assertEquals(2, healthMap.size());
             ServiceHealth health =healthMap.get(serviceKey1);
             ServiceHealth health2 = healthMap.get(serviceKey2);
 

--- a/src/test/java/com/orbitz/consul/option/ConsistencyModeTest.java
+++ b/src/test/java/com/orbitz/consul/option/ConsistencyModeTest.java
@@ -10,16 +10,16 @@ public class ConsistencyModeTest {
 
     @Test
     public void checkCompatinbilityWithOldEnum(){
-        assertEquals(ConsistencyMode.values().length, 3);
+        assertEquals(3, ConsistencyMode.values().length);
         for (int i = 0; i < ConsistencyMode.values().length; i++) {
             assertEquals(ConsistencyMode.values()[i].ordinal(), i);
         }
-        assertEquals(ConsistencyMode.values()[0], ConsistencyMode.DEFAULT);
-        assertEquals(ConsistencyMode.values()[0].name(), "DEFAULT");
-        assertEquals(ConsistencyMode.values()[1], ConsistencyMode.STALE);
-        assertEquals(ConsistencyMode.values()[1].name(), "STALE");
-        assertEquals(ConsistencyMode.values()[2], ConsistencyMode.CONSISTENT);
-        assertEquals(ConsistencyMode.values()[2].name(), "CONSISTENT");
+        assertEquals(ConsistencyMode.DEFAULT, ConsistencyMode.values()[0]);
+        assertEquals("DEFAULT", ConsistencyMode.values()[0].name());
+        assertEquals(ConsistencyMode.STALE, ConsistencyMode.values()[1]);
+        assertEquals("STALE", ConsistencyMode.values()[1].name());
+        assertEquals(ConsistencyMode.CONSISTENT, ConsistencyMode.values()[2]);
+        assertEquals("CONSISTENT", ConsistencyMode.values()[2].name());
     }
 
     @Test


### PR DESCRIPTION
Sonar ID  java:S3415
Assertion arguments should be passed in the correct order

Part of #74