### PR TITLE
Sonar: Add the missing @deprecated Javadoc tag

### DIFF
--- a/src/main/java/com/orbitz/consul/AclClient.java
+++ b/src/main/java/com/orbitz/consul/AclClient.java
@@ -23,31 +23,49 @@ public class AclClient extends BaseClient {
         this.api = retrofit.create(Api.class);
     }
 
+    /**
+     * @deprecated this method will be removed in a future release; it has no replacement
+     */
     @Deprecated(since = "0.5.0", forRemoval = true)
     public String createAcl(AclToken aclToken) {
         return http.extract(api.createAcl(aclToken)).id();
     }
 
+    /**
+     * @deprecated this method will be removed in a future release; it has no replacement
+     */
     @Deprecated(since = "0.5.0", forRemoval = true)
     public void updateAcl(AclToken aclToken) {
         http.handle(api.updateAcl(aclToken));
     }
 
+    /**
+     * @deprecated this method will be removed in a future release; it has no replacement
+     */
     @Deprecated(since = "0.5.0", forRemoval = true)
     public void destroyAcl(String id) {
         http.handle(api.destroyAcl(id));
     }
 
+    /**
+     * @deprecated this method will be removed in a future release; it has no replacement
+     */
     @Deprecated(since = "0.5.0", forRemoval = true)
     public List<AclResponse> getAclInfo(String id) {
         return http.extract(api.getAclInfo(id));
     }
 
+    /**
+     * @deprecated this method will be removed in a future release; it has no replacement
+     */
     @Deprecated(since = "0.5.0", forRemoval = true)
     public String cloneAcl(String id) {
         return http.extract(api.cloneAcl(id)).id();
     }
 
+    /**
+     * @deprecated this method will be removed in a future release; it has no replacement
+     */
     @Deprecated(since = "0.5.0", forRemoval = true)
     public List<AclResponse> listAcls() {
         return http.extract(api.listAcls());
@@ -139,26 +157,44 @@ public class AclClient extends BaseClient {
 
     interface Api {
 
+        /**
+         * @deprecated this method will be removed in a future release; it has no replacement
+         */
         @Deprecated(since = "0.5.0", forRemoval = true)
         @PUT("acl/create")
         Call<AclTokenId> createAcl(@Body AclToken aclToken);
 
+        /**
+         * @deprecated this method will be removed in a future release; it has no replacement
+         */
         @Deprecated(since = "0.5.0", forRemoval = true)
         @PUT("acl/update")
         Call<Void> updateAcl(@Body AclToken aclToken);
 
+        /**
+         * @deprecated this method will be removed in a future release; it has no replacement
+         */
         @Deprecated(since = "0.5.0", forRemoval = true)
         @PUT("acl/destroy/{id}")
         Call<Void> destroyAcl(@Path("id") String id);
 
+        /**
+         * @deprecated this method will be removed in a future release; it has no replacement
+         */
         @Deprecated(since = "0.5.0", forRemoval = true)
         @GET("acl/info/{id}")
         Call<List<AclResponse>> getAclInfo(@Path("id") String id);
 
+        /**
+         * @deprecated this method will be removed in a future release; it has no replacement
+         */
         @Deprecated(since = "0.5.0", forRemoval = true)
         @PUT("acl/clone/{id}")
         Call<AclTokenId> cloneAcl(@Path("id") String id);
 
+        /**
+         * @deprecated this method will be removed in a future release; it has no replacement
+         */
         @Deprecated(since = "0.5.0", forRemoval = true)
         @GET("acl/list")
         Call<List<AclResponse>> listAcls();


### PR DESCRIPTION
Sonar issue java:S1123
Deprecated elements should have both the annotation and the Javadoc tag

Part of #74