### PR TITLE
Sonar: make static CLIENT_NAME fields final

### DIFF
--- a/src/main/java/com/orbitz/consul/AclClient.java
+++ b/src/main/java/com/orbitz/consul/AclClient.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public class AclClient extends BaseClient {
 
-    private static String CLIENT_NAME = "acl";
+    private static final String CLIENT_NAME = "acl";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -29,7 +29,7 @@ import java.util.Optional;
  */
 public class AgentClient extends BaseClient {
 
-    private static String CLIENT_NAME = "agent";
+    private static final String CLIENT_NAME = "agent";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/CatalogClient.java
+++ b/src/main/java/com/orbitz/consul/CatalogClient.java
@@ -22,7 +22,7 @@ import java.util.Map;
  */
 public class CatalogClient extends BaseCacheableClient {
 
-    private static String CLIENT_NAME = "catalog";
+    private static final String CLIENT_NAME = "catalog";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/CoordinateClient.java
+++ b/src/main/java/com/orbitz/consul/CoordinateClient.java
@@ -20,7 +20,7 @@ import java.util.Map;
  */
 public class CoordinateClient extends BaseClient {
 
-    private static String CLIENT_NAME = "coordinate";
+    private static final String CLIENT_NAME = "coordinate";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/EventClient.java
+++ b/src/main/java/com/orbitz/consul/EventClient.java
@@ -27,7 +27,7 @@ import java.util.Map;
  */
 public class EventClient extends BaseClient {
 
-    private static String CLIENT_NAME = "event";
+    private static final String CLIENT_NAME = "event";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/HealthClient.java
+++ b/src/main/java/com/orbitz/consul/HealthClient.java
@@ -25,7 +25,7 @@ import java.util.Map;
  */
 public class HealthClient extends BaseCacheableClient {
 
-    private static String CLIENT_NAME = "health";
+    private static final String CLIENT_NAME = "health";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -49,7 +49,7 @@ import static com.orbitz.consul.util.Strings.trimLeadingSlash;
  */
 public class KeyValueClient extends BaseCacheableClient {
 
-    private static String CLIENT_NAME = "keyvalue";
+    private static final String CLIENT_NAME = "keyvalue";
     public static final int NOT_FOUND_404 = 404;
 
     private final Api api;

--- a/src/main/java/com/orbitz/consul/OperatorClient.java
+++ b/src/main/java/com/orbitz/consul/OperatorClient.java
@@ -14,7 +14,7 @@ import java.util.Map;
 
 public class OperatorClient extends BaseClient {
 
-    private static String CLIENT_NAME = "operator";
+    private static final String CLIENT_NAME = "operator";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/PreparedQueryClient.java
+++ b/src/main/java/com/orbitz/consul/PreparedQueryClient.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 public class PreparedQueryClient extends BaseClient {
 
-    private static String CLIENT_NAME = "preparedquery";
+    private static final String CLIENT_NAME = "preparedquery";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/SessionClient.java
+++ b/src/main/java/com/orbitz/consul/SessionClient.java
@@ -20,7 +20,7 @@ import java.util.Optional;
  */
 public class SessionClient extends BaseClient {
 
-    private static String CLIENT_NAME = "session";
+    private static final String CLIENT_NAME = "session";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/SnapshotClient.java
+++ b/src/main/java/com/orbitz/consul/SnapshotClient.java
@@ -28,7 +28,7 @@ import java.util.Map;
  */
 public class SnapshotClient extends BaseClient {
 
-    private static String CLIENT_NAME = "snapshot";
+    private static final String CLIENT_NAME = "snapshot";
 
     private final Api api;
 

--- a/src/main/java/com/orbitz/consul/StatusClient.java
+++ b/src/main/java/com/orbitz/consul/StatusClient.java
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class StatusClient extends BaseClient {
 
-    private static String CLIENT_NAME = "status";
+    private static final String CLIENT_NAME = "status";
 
     private final Api api;
 


### PR DESCRIPTION
Each "Client" class has a static (but not final) CLIENT_NAME field which is basically a constant. Fix the Sonar issue by making these fields final so that they are effectively constants.

Original Sonar issue java:S3008
Static non-final field names should comply with a naming convention

Part of #74