### PR TITLE
Sonar: Define a constant instead of duplicating literals

### DIFF
--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -265,6 +265,9 @@ public class Consul {
     * Builder for {@link Consul} client objects.
     */
     public static class Builder {
+
+        private static final String NEGATIVE_VALUE = "Negative value";
+
         private String scheme = "http";
         private URL url;
         private SSLContext sslContext;
@@ -571,7 +574,7 @@ public class Consul {
         * @return The builder
         */
         public Builder withConnectTimeoutMillis(long timeoutMillis) {
-            Preconditions.checkArgument(timeoutMillis >= 0, "Negative value");
+            Preconditions.checkArgument(timeoutMillis >= 0, NEGATIVE_VALUE);
             this.networkTimeoutConfigBuilder.withConnectTimeout((int) timeoutMillis);
             return this;
         }
@@ -582,7 +585,7 @@ public class Consul {
         * @return The builder
         */
         public Builder withReadTimeoutMillis(long timeoutMillis) {
-            Preconditions.checkArgument(timeoutMillis >= 0, "Negative value");
+            Preconditions.checkArgument(timeoutMillis >= 0, NEGATIVE_VALUE);
             this.networkTimeoutConfigBuilder.withReadTimeout((int) timeoutMillis);
 
             return this;
@@ -594,7 +597,7 @@ public class Consul {
         * @return The builder
         */
         public Builder withWriteTimeoutMillis(long timeoutMillis) {
-            Preconditions.checkArgument(timeoutMillis >= 0, "Negative value");
+            Preconditions.checkArgument(timeoutMillis >= 0, NEGATIVE_VALUE);
             this.networkTimeoutConfigBuilder.withWriteTimeout((int) timeoutMillis);
 
             return this;

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -50,6 +50,9 @@ import static com.orbitz.consul.util.Strings.trimLeadingSlash;
 public class KeyValueClient extends BaseCacheableClient {
 
     private static final String CLIENT_NAME = "keyvalue";
+    private static final String KEY_MUST_BE_DEFINED = "Key must be defined";
+    private static final String RECURSE = "recurse";
+
     public static final int NOT_FOUND_404 = 404;
 
     private final Api api;
@@ -222,7 +225,7 @@ public class KeyValueClient extends BaseCacheableClient {
     public List<Value> getValues(String key, QueryOptions queryOptions) {
         Map<String, Object> query = queryOptions.toQuery();
 
-        query.put("recurse", "true");
+        query.put(RECURSE, "true");
 
         List<Value> result = http.extract(api.getValue(trimLeadingSlash(key), query), NOT_FOUND_404);
 
@@ -243,7 +246,7 @@ public class KeyValueClient extends BaseCacheableClient {
     public ConsulResponse<List<Value>> getConsulResponseWithValues(String key, QueryOptions queryOptions) {
         Map<String, Object> query = queryOptions.toQuery();
 
-        query.put("recurse", "true");
+        query.put(RECURSE, "true");
 
         return http.extractConsulResponse(api.getValue(trimLeadingSlash(key), query), NOT_FOUND_404);
     }
@@ -261,7 +264,7 @@ public class KeyValueClient extends BaseCacheableClient {
     public void getValues(String key, QueryOptions queryOptions, ConsulResponseCallback<List<Value>> callback) {
         Map<String, Object> query = queryOptions.toQuery();
 
-        query.put("recurse", "true");
+        query.put(RECURSE, "true");
 
         http.extractConsulResponse(api.getValue(trimLeadingSlash(key), query), callback, NOT_FOUND_404);
     }
@@ -404,7 +407,7 @@ public class KeyValueClient extends BaseCacheableClient {
      */
     public boolean putValue(String key, String value, long flags, PutOptions putOptions, Charset charset) {
 
-        checkArgument(StringUtils.isNotEmpty(key), "Key must be defined");
+        checkArgument(StringUtils.isNotEmpty(key), KEY_MUST_BE_DEFINED);
         Map<String, Object> query = putOptions.toQuery();
 
         if (flags != 0) {
@@ -430,7 +433,7 @@ public class KeyValueClient extends BaseCacheableClient {
      */
     public boolean putValue(String key, byte[] value, long flags, PutOptions putOptions) {
 
-        checkArgument(StringUtils.isNotEmpty(key), "Key must be defined");
+        checkArgument(StringUtils.isNotEmpty(key), KEY_MUST_BE_DEFINED);
         Map<String, Object> query = putOptions.toQuery();
 
         if (flags != 0) {
@@ -537,7 +540,7 @@ public class KeyValueClient extends BaseCacheableClient {
      * @param deleteOptions DELETE options (e.g. recurse, cas)
      */
     public void deleteKey(String key, DeleteOptions deleteOptions) {
-        checkArgument(StringUtils.isNotEmpty(key), "Key must be defined");
+        checkArgument(StringUtils.isNotEmpty(key), KEY_MUST_BE_DEFINED);
         Map<String, Object> query = deleteOptions.toQuery();
 
         http.handle(api.deleteValues(trimLeadingSlash(key), query));

--- a/src/main/java/com/orbitz/consul/config/CacheConfig.java
+++ b/src/main/java/com/orbitz/consul/config/CacheConfig.java
@@ -112,6 +112,9 @@ public class CacheConfig {
     }
 
     public static class Builder {
+
+        private static final String DELAY_CANNOT_BE_NULL = "Delay cannot be null";
+
         private Duration watchDuration = DEFAULT_WATCH_DURATION;
         private Duration minBackOffDelay = DEFAULT_BACKOFF_DELAY;
         private Duration maxBackOffDelay = DEFAULT_BACKOFF_DELAY;
@@ -130,7 +133,7 @@ public class CacheConfig {
          * @throws IllegalArgumentException if {@code delay} is negative.
          */
         public Builder withWatchDuration(Duration delay) {
-            this.watchDuration = Preconditions.checkNotNull(delay, "Delay cannot be null");
+            this.watchDuration = Preconditions.checkNotNull(delay, DELAY_CANNOT_BE_NULL);
             Preconditions.checkArgument(!delay.isNegative(), "Delay must be positive");
             return this;
         }
@@ -140,7 +143,7 @@ public class CacheConfig {
          * @throws IllegalArgumentException if {@code delay} is negative.
          */
         public Builder withBackOffDelay(Duration delay) {
-            this.minBackOffDelay = Preconditions.checkNotNull(delay, "Delay cannot be null");
+            this.minBackOffDelay = Preconditions.checkNotNull(delay, DELAY_CANNOT_BE_NULL);
             this.maxBackOffDelay = delay;
             Preconditions.checkArgument(!delay.isNegative(), "Delay must be positive");
             return this;
@@ -162,7 +165,7 @@ public class CacheConfig {
          * Sets the minimum time between two requests for caches.
          */
         public Builder withMinDelayBetweenRequests(Duration delay) {
-            this.minDelayBetweenRequests = Preconditions.checkNotNull(delay, "Delay cannot be null");
+            this.minDelayBetweenRequests = Preconditions.checkNotNull(delay, DELAY_CANNOT_BE_NULL);
             return this;
         }
 
@@ -170,7 +173,7 @@ public class CacheConfig {
          * Sets the minimum time between two requests for caches when an empty result is returned.
          */
         public Builder withMinDelayOnEmptyResult(Duration delay) {
-            this.minDelayOnEmptyResult = Preconditions.checkNotNull(delay, "Delay cannot be null");
+            this.minDelayOnEmptyResult = Preconditions.checkNotNull(delay, DELAY_CANNOT_BE_NULL);
             return this;
         }
 


### PR DESCRIPTION
Sonar issue java:S1192
String literals should not be duplicated

Part of #74