### PR TITLE
Sonar: Use dedicated exceptions; private constructor in util classes

### DIFF
--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -23,6 +23,7 @@ import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.monitoring.ClientEventCallback;
 import com.orbitz.consul.util.Jackson;
 import com.orbitz.consul.util.TrustManagerUtils;
+import com.orbitz.consul.util.UncheckedMalformedURLException;
 import com.orbitz.consul.util.bookend.ConsulBookend;
 import com.orbitz.consul.util.bookend.ConsulBookendInterceptor;
 import com.orbitz.consul.util.failover.ConsulFailoverInterceptor;
@@ -304,7 +305,7 @@ public class Consul {
             try {
                 url = new URL(scheme, DEFAULT_HTTP_HOST, DEFAULT_HTTP_PORT, "");
             } catch (MalformedURLException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedMalformedURLException(e);
             }
         }
 
@@ -339,7 +340,7 @@ public class Consul {
                 try {
                     this.url = new URL(scheme, this.url.getHost(), this.url.getPort(), "");
                 } catch (MalformedURLException e) {
-                    throw new RuntimeException(e);
+                    throw new UncheckedMalformedURLException(e);
                 }
             }
             return this;
@@ -474,7 +475,7 @@ public class Consul {
             try {
                 this.url = new URL(scheme, hostAndPort.getHost(), hostAndPort.getPort(), "");
             } catch (MalformedURLException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedMalformedURLException(e);
             }
 
             return this;
@@ -521,7 +522,7 @@ public class Consul {
             try {
                 this.url = new URL(url);
             } catch (MalformedURLException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedMalformedURLException(e);
             }
 
             return this;
@@ -720,7 +721,7 @@ public class Consul {
                         Jackson.MAPPER,
                         okHttpClient);
             } catch (MalformedURLException e) {
-                throw new RuntimeException(e);
+                throw new UncheckedMalformedURLException(e);
             }
 
             ClientEventCallback eventCallback = clientEventCallback != null ?

--- a/src/main/java/com/orbitz/consul/util/Strings.java
+++ b/src/main/java/com/orbitz/consul/util/Strings.java
@@ -2,6 +2,10 @@ package com.orbitz.consul.util;
 
 public class Strings {
 
+    private Strings() {
+        // utility class
+    }
+
     public static String trimLeadingSlash(String value) {
         return value.replaceAll("^/+", "");
     }

--- a/src/main/java/com/orbitz/consul/util/TrustManagerUtils.java
+++ b/src/main/java/com/orbitz/consul/util/TrustManagerUtils.java
@@ -8,18 +8,23 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 
 public class TrustManagerUtils {
+
+    private TrustManagerUtils() {
+        // utility class
+    }
+
     public static X509TrustManager getDefaultTrustManager() {
         try {
             TrustManagerFactory factory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
             factory.init((KeyStore) null);
             for (TrustManager manager : factory.getTrustManagers()) {
-                if(manager instanceof X509TrustManager) {
+                if (manager instanceof X509TrustManager) {
                     return (X509TrustManager) manager;
                 }
             }
             throw new IllegalStateException("Default X509TrustManager not found");
         } catch (NoSuchAlgorithmException | KeyStoreException e) {
-            throw new Error(e);
+            throw new UncheckedGeneralSecurityException(e);
         }
     }
 

--- a/src/main/java/com/orbitz/consul/util/UncheckedGeneralSecurityException.java
+++ b/src/main/java/com/orbitz/consul/util/UncheckedGeneralSecurityException.java
@@ -1,0 +1,24 @@
+package com.orbitz.consul.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.security.GeneralSecurityException;
+
+/**
+ * Wraps a {@link GeneralSecurityException} with an unchecked exception.
+ */
+public class UncheckedGeneralSecurityException extends RuntimeException {
+
+    public UncheckedGeneralSecurityException(GeneralSecurityException cause) {
+        super(requireNonNull(cause));
+    }
+
+    public UncheckedGeneralSecurityException(String message, GeneralSecurityException cause) {
+        super(message, requireNonNull(cause));
+    }
+
+    @Override
+    public synchronized GeneralSecurityException getCause() {
+        return (GeneralSecurityException) super.getCause();
+    }
+}

--- a/src/main/java/com/orbitz/consul/util/UncheckedMalformedURLException.java
+++ b/src/main/java/com/orbitz/consul/util/UncheckedMalformedURLException.java
@@ -1,0 +1,27 @@
+package com.orbitz.consul.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.MalformedURLException;
+
+/**
+ * Wraps a {@link MalformedURLException} with an unchecked exception.
+ *
+ * @implNote This is copied from <a href="https://github.com/kiwiproject/kiwi">kiwi</a>. In the future
+ * we may add kiwi as a dependency to this library, and then this can be replaced with the one in kiwi.
+ */
+public class UncheckedMalformedURLException extends RuntimeException {
+
+    public UncheckedMalformedURLException(MalformedURLException cause) {
+        super(requireNonNull(cause));
+    }
+
+    public UncheckedMalformedURLException(String message, MalformedURLException cause) {
+        super(message, requireNonNull(cause));
+    }
+
+    @Override
+    public synchronized MalformedURLException getCause() {
+        return (MalformedURLException) super.getCause();
+    }
+}

--- a/src/main/java/com/orbitz/consul/util/Urls.java
+++ b/src/main/java/com/orbitz/consul/util/Urls.java
@@ -1,0 +1,31 @@
+package com.orbitz.consul.util;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class Urls {
+
+    private Urls() {
+        // utility class
+    }
+
+    public static URL newUrl(String urlString) {
+        try {
+            return new URL(urlString);
+        } catch (MalformedURLException e) {
+            throw new UncheckedMalformedURLException(e);
+        }
+    }
+
+    public static URL newUrl(String scheme, String host, int port) {
+        return newUrl(scheme, host, port, "");
+    }
+
+    public static URL newUrl(String scheme, String host, int port, String file) {
+        try {
+            return new URL(scheme, host, port, file);
+        } catch (MalformedURLException e) {
+            throw new UncheckedMalformedURLException(e);
+        }
+    }
+}

--- a/src/test/java/com/orbitz/consul/util/UncheckedGeneralSecurityExceptionTest.java
+++ b/src/test/java/com/orbitz/consul/util/UncheckedGeneralSecurityExceptionTest.java
@@ -1,0 +1,36 @@
+package com.orbitz.consul.util;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+import java.security.GeneralSecurityException;
+import java.security.NoSuchAlgorithmException;
+
+public class UncheckedGeneralSecurityExceptionTest {
+
+    @Test
+    public void testConstructWithMessage() {
+        var cause = newGeneralSecurityException();
+        var exception = new UncheckedGeneralSecurityException("nope", cause);
+
+        assertEquals("nope", exception.getMessage());
+        assertSame(cause, exception.getCause());
+    }
+
+    @Test
+    public void testConstructWithoutMessage() {
+        var cause = newGeneralSecurityException();
+        var exception = new UncheckedGeneralSecurityException(cause);
+
+        assertThat(exception.getMessage(), containsString(cause.getMessage()));
+        assertSame(cause, exception.getCause());
+    }
+
+    private static GeneralSecurityException newGeneralSecurityException() {
+        return new NoSuchAlgorithmException("bad algorithm: FooBar123");
+    }
+}

--- a/src/test/java/com/orbitz/consul/util/UncheckedMalformedURLExceptionTest.java
+++ b/src/test/java/com/orbitz/consul/util/UncheckedMalformedURLExceptionTest.java
@@ -1,0 +1,39 @@
+package com.orbitz.consul.util;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+import java.net.MalformedURLException;
+
+/**
+ * @implNote Copied from  <a href="https://github.com/kiwiproject/kiwi">kiwi</a> and modified
+ * because as of now, this library uses JUnit 4 and Hamcrest matchers.
+ */
+public class UncheckedMalformedURLExceptionTest {
+
+    @Test
+    public void testConstructWithMessage() {
+        var cause = newMalformedURLException();
+        var exception = new UncheckedMalformedURLException("nope", cause);
+
+        assertEquals("nope", exception.getMessage());
+        assertSame(cause, exception.getCause());
+    }
+
+    @Test
+    public void testConstructWithoutMessage() {
+        var cause = newMalformedURLException();
+        var exception = new UncheckedMalformedURLException(cause);
+
+        assertThat(exception.getMessage(), containsString(cause.getMessage()));
+        assertSame(cause, exception.getCause());
+    }
+
+    private static MalformedURLException newMalformedURLException() {
+        return new MalformedURLException("bad URL");
+    }
+}

--- a/src/test/java/com/orbitz/consul/util/UrlsTest.java
+++ b/src/test/java/com/orbitz/consul/util/UrlsTest.java
@@ -1,0 +1,35 @@
+package com.orbitz.consul.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.Test;
+
+public class UrlsTest {
+
+    @Test
+    public void shouldCreateNewUrl_FromString() {
+        var urlString = "https://github.com/kiwiproject/consul-client";
+        var url = Urls.newUrl(urlString);
+
+        assertEquals(urlString, url.toString());
+    }
+
+    @Test
+    public void shouldCreateNewUrl_FromString_AndThrow_WhenMalformed() {
+        assertThrows(UncheckedMalformedURLException.class, () -> Urls.newUrl("oops"));
+    }
+
+    @Test
+    public void shouldCreateNewUrl_FromComponents() {
+        var url = Urls.newUrl("https", "github.com", 443);
+
+        assertEquals("https://github.com:443", url.toString());
+    }
+
+    @Test
+    public void shouldCreateNewUrl_FromComponents_AndThrow_WhenMalformed() {
+        assertThrows(UncheckedMalformedURLException.class,
+                () -> Urls.newUrl("bad_protocol", "github.com", 8080));
+    }
+}


### PR DESCRIPTION
Fixes:
* java:S112 - Generic exceptions should never be thrown
* java:S1118 - Utility classes should not have public constructors

New classes:
* UncheckedMalformedURLException (a RuntimeException)
* UncheckedGeneralSecurityException (a RuntimeException)
* Urls (a utility class to create URL objects and handle the MalformedURLExceptions)

Part of #74