### PR TITLE
Reformat constructors in Consul and CacheConfig

### DIFF
--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -74,17 +74,23 @@ public class Consul {
     private boolean destroyed;
 
     /**
-    * Private constructor.
-    *
-    */
-    protected Consul(AgentClient agentClient, HealthClient healthClient,
-                KeyValueClient keyValueClient, CatalogClient catalogClient,
-                StatusClient statusClient, SessionClient sessionClient,
-                EventClient eventClient, PreparedQueryClient preparedQueryClient,
-                CoordinateClient coordinateClient, OperatorClient operatorClient,
-                ExecutorService executorService, ConnectionPool connectionPool,
-                AclClient aclClient, SnapshotClient snapshotClient,
-                OkHttpClient okHttpClient) {
+     * Package-private constructor.
+     */
+    protected Consul(AgentClient agentClient,
+                     HealthClient healthClient,
+                     KeyValueClient keyValueClient,
+                     CatalogClient catalogClient,
+                     StatusClient statusClient,
+                     SessionClient sessionClient,
+                     EventClient eventClient,
+                     PreparedQueryClient preparedQueryClient,
+                     CoordinateClient coordinateClient,
+                     OperatorClient operatorClient,
+                     ExecutorService executorService,
+                     ConnectionPool connectionPool,
+                     AclClient aclClient,
+                     SnapshotClient snapshotClient,
+                     OkHttpClient okHttpClient) {
         this.agentClient = agentClient;
         this.healthClient = healthClient;
         this.keyValueClient = keyValueClient;
@@ -720,10 +726,21 @@ public class Consul {
             if (ping) {
                 agentClient.ping();
             }
-            return new Consul(agentClient, healthClient, keyValueClient,
-                    catalogClient, statusClient, sessionClient, eventClient,
-                    preparedQueryClient, coordinateClient, operatorClient,
-                    localExecutorService, connectionPool, aclClient, snapshotClient, okHttpClient);
+            return new Consul(agentClient,
+                    healthClient,
+                    keyValueClient,
+                    catalogClient,
+                    statusClient,
+                    sessionClient,
+                    eventClient,
+                    preparedQueryClient,
+                    coordinateClient,
+                    operatorClient,
+                    localExecutorService,
+                    connectionPool,
+                    aclClient,
+                    snapshotClient,
+                    okHttpClient);
         }
 
         private String buildUrl(URL url) {

--- a/src/main/java/com/orbitz/consul/config/CacheConfig.java
+++ b/src/main/java/com/orbitz/consul/config/CacheConfig.java
@@ -32,9 +32,14 @@ public class CacheConfig {
     private final boolean timeoutAutoAdjustmentEnabled;
     private final RefreshErrorLogConsumer refreshErrorLogConsumer;
 
-    private CacheConfig(Duration watchDuration, Duration minBackOffDelay, Duration maxBackOffDelay, Duration minDelayBetweenRequests,
-                        Duration minDelayOnEmptyResult, boolean timeoutAutoAdjustmentEnabled,
-                        Duration timeoutAutoAdjustmentMargin, RefreshErrorLogConsumer refreshErrorLogConsumer) {
+    private CacheConfig(Duration watchDuration,
+                        Duration minBackOffDelay,
+                        Duration maxBackOffDelay,
+                        Duration minDelayBetweenRequests,
+                        Duration minDelayOnEmptyResult,
+                        boolean timeoutAutoAdjustmentEnabled,
+                        Duration timeoutAutoAdjustmentMargin,
+                        RefreshErrorLogConsumer refreshErrorLogConsumer) {
         this.watchDuration = watchDuration;
         this.minBackOffDelay = minBackOffDelay;
         this.maxBackOffDelay = maxBackOffDelay;
@@ -219,8 +224,13 @@ public class CacheConfig {
         }
 
         public CacheConfig build() {
-            return new CacheConfig(watchDuration, minBackOffDelay, maxBackOffDelay, minDelayBetweenRequests, minDelayOnEmptyResult,
-                    timeoutAutoAdjustmentEnabled, timeoutAutoAdjustmentMargin,
+            return new CacheConfig(watchDuration,
+                    minBackOffDelay,
+                    maxBackOffDelay,
+                    minDelayBetweenRequests,
+                    minDelayOnEmptyResult,
+                    timeoutAutoAdjustmentEnabled,
+                    timeoutAutoAdjustmentMargin,
                     refreshErrorLogConsumer);
         }
     }


### PR DESCRIPTION
These are (non-public) constructors for use by the builders, so the lage number of parameters is unavoidable.

Reformat these constructors so that each argument is on a separate line, mainly for readability.

The Sonar warnings will be resolved in the Sonar UI. The resolution is "Won't fix" for the reasons stated above.

Part of #74