### PR TITLE
Fix StoredQuery JSON deserialization errors

### DIFF
--- a/src/itest/java/com/orbitz/consul/PreparedQueryITest.java
+++ b/src/itest/java/com/orbitz/consul/PreparedQueryITest.java
@@ -1,42 +1,160 @@
 package com.orbitz.consul;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
-import com.google.common.net.HostAndPort;
+
+import static java.util.stream.Collectors.toList;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.orbitz.consul.model.query.Failover;
+import com.orbitz.consul.model.query.ImmutableFailover;
 import com.orbitz.consul.model.query.ImmutablePreparedQuery;
 import com.orbitz.consul.model.query.ImmutableServiceQuery;
 import com.orbitz.consul.model.query.PreparedQuery;
 import com.orbitz.consul.model.query.StoredQuery;
-import org.junit.Ignore;
+
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.UUID;
 
 public class PreparedQueryITest extends BaseIntegrationTest {
 
-    @Test
-    @Ignore
-    public void shouldWork() {
-        String service = UUID.randomUUID().toString();
-        String query = UUID.randomUUID().toString();
-        Consul consul = Consul.builder().withHostAndPort(HostAndPort.fromParts("192.168.99.100", consulContainer.getFirstMappedPort())).build();
-        consul.agentClient().register(8080, 10000L, service, service + "1", Collections.emptyList(), Collections.emptyMap());
-        PreparedQueryClient preparedQueryClient = consul.preparedQueryClient();
+    private PreparedQueryClient preparedQueryClient;
+    private List<String> queryIdsToDelete;
 
-        PreparedQuery preparedQuery = ImmutablePreparedQuery.builder()
+    @Before
+    public void setUp() {
+        preparedQueryClient = client.preparedQueryClient();
+        queryIdsToDelete = new ArrayList<>();
+    }
+
+    @After
+    public void tearDown() {
+        queryIdsToDelete.forEach(id -> preparedQueryClient.deletePreparedQuery(id));
+    }
+
+    @Test
+    public void shouldCreateAndFindPreparedQuery() {
+        var serviceName = UUID.randomUUID().toString();
+        var query = UUID.randomUUID().toString();
+        client.agentClient().register(8080, 10000L, serviceName, serviceName + "1", Collections.emptyList(), Collections.emptyMap());
+
+        var preparedQuery = ImmutablePreparedQuery.builder()
                 .name(query)
                 .token("")
                 .service(ImmutableServiceQuery.builder()
-                        .service(service)
+                        .service(serviceName)
                         .onlyPassing(true)
                         .build())
                 .build();
 
-        String id = preparedQueryClient.createPreparedQuery(preparedQuery);
+        var id = createPreparedQuery(preparedQuery);
 
-        Optional<StoredQuery> storedQuery = preparedQueryClient.getPreparedQuery(id);
-        //ConsulResponse<List<ServiceHealth>> result = preparedQueryClient.executeQuery(id);
+        Optional<StoredQuery> maybeStoredQuery = preparedQueryClient.getPreparedQuery(id);
+        assertTrue(maybeStoredQuery.isPresent());
 
-        //assertEquals(id, storedQuery.get().getId());
+        var storedQuery = maybeStoredQuery.get();
+        assertThat(storedQuery.getId(), is(id));
+        assertThat(storedQuery.getName(), is(query));
+        assertThat(storedQuery.getService().getService(), is(serviceName));
+        assertTrue(storedQuery.getService().getFailover().isPresent());
+        assertTrue(storedQuery.getService().getFailover().get().datacenters().isEmpty());
+    }
+
+    @Test
+    public void shouldCreatePreparedQueryWithFailoverProperties() {
+        var serviceName = UUID.randomUUID().toString();
+        var query = UUID.randomUUID().toString();
+        client.agentClient().register(8080, 10000L, serviceName, serviceName + "1", Collections.emptyList(), Collections.emptyMap());
+
+        var preparedQuery = ImmutablePreparedQuery.builder()
+                .name(query)
+                .token("")
+                .service(ImmutableServiceQuery.builder()
+                        .service(serviceName)
+                        .onlyPassing(true)
+                        .failover(ImmutableFailover.builder()
+                                .nearestN(3)
+                                .datacenters(List.of("dc1", "dc2"))
+                                .build())
+                        .build())
+                .build();
+
+        var id = createPreparedQuery(preparedQuery);
+
+        Optional<StoredQuery> maybeStoredQuery = preparedQueryClient.getPreparedQuery(id);
+        assertTrue(maybeStoredQuery.isPresent());
+
+        var storedQuery = maybeStoredQuery.get();
+        assertThat(storedQuery.getId(), is(id));
+        assertThat(storedQuery.getName(), is(query));
+
+        Optional<Failover> maybeFailover = storedQuery.getService().getFailover();
+        assertTrue(maybeFailover.isPresent());
+
+        var failover = maybeFailover.get();
+        assertThat(failover.getNearestN(), is(Optional.of(3)));
+        assertThat(failover.datacenters(), is(Optional.of(List.of("dc1", "dc2"))));
+    }
+
+    @Test
+    public void shouldListPreparedQueries() {
+        var serviceName1 = UUID.randomUUID().toString();
+        var query1 = UUID.randomUUID().toString();
+        client.agentClient().register(8080, 10000L, serviceName1, serviceName1 + "_id", Collections.emptyList(), Collections.emptyMap());
+
+        var serviceName2 = UUID.randomUUID().toString();
+        var query2 = UUID.randomUUID().toString();
+        client.agentClient().register(8080, 10000L, serviceName2, serviceName2 + "_id", Collections.emptyList(), Collections.emptyMap());
+
+        var preparedQuery1 = ImmutablePreparedQuery.builder()
+                .name(query1)
+                .token("")
+                .service(ImmutableServiceQuery.builder()
+                        .service(serviceName1)
+                        .onlyPassing(true)
+                        .build())
+                .build();
+
+        var id1 = createPreparedQuery(preparedQuery1);
+
+        var preparedQuery2 = ImmutablePreparedQuery.builder()
+                .name(query2)
+                .token("")
+                .service(ImmutableServiceQuery.builder()
+                        .service(serviceName1)
+                        .onlyPassing(true)
+                        .build())
+                .build();
+
+        var id2 = createPreparedQuery(preparedQuery2);
+
+        List<StoredQuery> storedQueries = preparedQueryClient.getPreparedQueries();
+
+        assertThat(storedQueries.size(), is(2));
+
+        List<String> queryIds = storedQueries.stream().map(StoredQuery::getId).collect(toList());
+        assertThat(queryIds, hasItems(id1, id2));
+
+        List<String> queryNames = storedQueries.stream().map(StoredQuery::getName).collect(toList());
+        assertThat(queryNames, hasItems(query1, query2));
+    }
+
+    /**
+     * Create a PreparedQuery which will be automatically deleted after test execution
+     *
+     * @return the ID of the stored PrepareQuery
+     */
+    private String createPreparedQuery(PreparedQuery preparedQuery) {
+        var id = preparedQueryClient.createPreparedQuery(preparedQuery);
+        queryIdsToDelete.add(id);
+        return id;
     }
 }

--- a/src/main/java/com/orbitz/consul/PreparedQueryClient.java
+++ b/src/main/java/com/orbitz/consul/PreparedQueryClient.java
@@ -134,6 +134,25 @@ public class PreparedQueryClient extends BaseClient {
     }
 
     /**
+     * Deletes a prepared query by its ID.
+     *
+     * @param id The query ID
+     */
+    public void deletePreparedQuery(String id) {
+        deletePreparedQuery(id, null);
+    }
+
+    /**
+     * Deletes a prepared query by its ID.
+     *
+     * @param id The query ID
+     * @param dc The data center
+     */
+    public void deletePreparedQuery(String id, String dc) {
+        http.extract(api.deletePreparedQuery(id, dcQuery(dc)));
+    }
+
+    /**
      * Retrofit API interface.
      */
     interface Api {
@@ -152,5 +171,9 @@ public class PreparedQueryClient extends BaseClient {
         @GET("query/{nameOrId}/execute")
         Call<QueryResults> execute(@Path("nameOrId") String nameOrId,
                                    @QueryMap Map<String, Object> queryMap);
+
+        @DELETE("query/{id}")
+        Call<Void> deletePreparedQuery(@Path("id") String id,
+                                       @QueryMap Map<String, String> queryMap);
     }
 }

--- a/src/main/java/com/orbitz/consul/model/query/Failover.java
+++ b/src/main/java/com/orbitz/consul/model/query/Failover.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +18,5 @@ public abstract class Failover {
     public abstract Optional<Integer> getNearestN();
 
     @JsonProperty("Datacenters")
-    @JsonDeserialize(as = ImmutableList.class, contentAs = String.class)
     public abstract Optional<List<String>> datacenters();
 }


### PR DESCRIPTION
* Remove the JsonSerialization annotation from Failover#datacenters since ImmutaleList is not a subtype of Optional<List<String>>
* Enable the PreparedQueryITest and refactor it, plus add new tests
* Add ability to delete prepared queries in PreparedQueryClient

Fixes #93
Closes #94