### PR TITLE
Replace deprecated Assert#assertThat with MatcherAssert

### DIFF
--- a/src/itest/java/com/orbitz/consul/AgentITest.java
+++ b/src/itest/java/com/orbitz/consul/AgentITest.java
@@ -17,6 +17,7 @@ import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.ImmutableQueryParameterOptions;
 import com.orbitz.consul.option.QueryOptions;
+
 import org.junit.Test;
 
 import java.net.MalformedURLException;
@@ -29,9 +30,13 @@ import java.util.Map;
 import java.util.UUID;
 
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class AgentITest extends BaseIntegrationTest {
 

--- a/src/itest/java/com/orbitz/consul/cache/KVCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/KVCacheITest.java
@@ -12,6 +12,7 @@ import com.orbitz.consul.Synchroniser;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,9 +24,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 @RunWith(JUnitParamsRunner.class)
 public class KVCacheITest extends BaseIntegrationTest {

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -13,7 +13,6 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.apache.commons.lang3.time.StopWatch;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.internal.matchers.GreaterOrEqual;
@@ -29,6 +28,7 @@ import java.util.function.Function;
 
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -110,7 +110,7 @@ public class ConsulCacheTest {
         CacheConfig cacheConfig = CacheConfig.builder().withBackOffDelay(minDelay, maxDelay).build();
         for (int i=0; i < 1000; i++) {
             long retryDurationMs = ConsulCache.computeBackOffDelayMs(cacheConfig);
-            Assert.assertThat(
+            assertThat(
                     String.format("Retry duration expected between %s and %s but got %d ms", minDelay, maxDelay, retryDurationMs),
                     retryDurationMs,
                     is(allOf(new GreaterOrEqual<>(minDelay.toMillis()), new LessOrEqual<>(maxDelay.toMillis()))));

--- a/src/test/java/com/orbitz/consul/util/HttpTest.java
+++ b/src/test/java/com/orbitz/consul/util/HttpTest.java
@@ -124,7 +124,7 @@ public class HttpTest {
     }
 
     private <U, V> void checkForInvalidRequest(Function<Call<U>, V> httpCall) throws IOException {
-        Response<String> response = Response.error(400, ResponseBody.create(MediaType.parse(""), "failure"));
+        Response<String> response = Response.error(400, ResponseBody.create("failure", MediaType.parse("")));
         Call<U> call = mock(Call.class);
         doReturn(response).when(call).execute();
 
@@ -201,7 +201,7 @@ public class HttpTest {
     }
 
     private <U, V> void checkInvalidEventIsSentWhenRequestIsInvalid(Function<Call<U>, V> httpCall) throws IOException {
-        Response<String> response = Response.error(400, ResponseBody.create(MediaType.parse(""), "failure"));
+        Response<String> response = Response.error(400, ResponseBody.create("failure", MediaType.parse("")));
         Call<U> call = mock(Call.class);
         doReturn(response).when(call).execute();
 
@@ -259,7 +259,7 @@ public class HttpTest {
         when(call.request()).thenReturn(request);
         Callback<String> callCallback = http.createCallback(call, callback);
 
-        Response<String> response = Response.error(400, ResponseBody.create(MediaType.parse(""), "failure"));
+        Response<String> response = Response.error(400, ResponseBody.create("failure", MediaType.parse("")));
         callCallback.onResponse(call, response);
         latch.await(1, TimeUnit.SECONDS);
 


### PR DESCRIPTION
* Change Assert#assertThat to MatcherAssert#assertThat
* Also, replace all "star import" with explicit imports in these tests
* Fix more deprecation warnings in HttpTest for ResponseBody#create

Closes #100
Part of #98