### PR TITLE
Replace Thread.sleep with Awaitility in (some) tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
         <java.version>11</java.version>
 
         <apache.commons.version>3.12.0</apache.commons.version>
+        <awaitility.version>4.2.0</awaitility.version>
         <build-helper-maven-plugin.version>3.4.0</build-helper-maven-plugin.version>
         <checker-qual.version>3.34.0</checker-qual.version>
         <commonscodec.version>1.15</commonscodec.version>
@@ -153,6 +154,13 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/src/itest/java/com/orbitz/consul/SnapshotClientITest.java
+++ b/src/itest/java/com/orbitz/consul/SnapshotClientITest.java
@@ -2,6 +2,8 @@ package com.orbitz.consul;
 
 import com.orbitz.consul.async.Callback;
 import com.orbitz.consul.option.QueryOptions;
+
+import org.awaitility.Durations;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -17,6 +19,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.*;
 
 public class SnapshotClientITest extends BaseIntegrationTest {
@@ -57,8 +60,8 @@ public class SnapshotClientITest extends BaseIntegrationTest {
         assertFalse(checkIfServiceExist(serviceName));
 
         ensureRestoreSnapshot();
-        Thread.sleep(Duration.ofSeconds(1).toMillis());
-        assertTrue(checkIfServiceExist(serviceName));
+
+        await().atMost(Durations.TWO_SECONDS).until(() -> checkIfServiceExist(serviceName));
     }
 
     private void ensureSaveSnapshot() throws InterruptedException {

--- a/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
@@ -1,5 +1,7 @@
 package com.orbitz.consul.cache;
 
+import static org.awaitility.Awaitility.await;
+
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.orbitz.consul.Consul;
 import com.orbitz.consul.KeyValueClient;
@@ -13,7 +15,7 @@ import com.orbitz.consul.monitoring.ClientEventCallback;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
-import org.apache.commons.lang3.time.StopWatch;
+import org.awaitility.Durations;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -107,12 +109,7 @@ public class KVCacheTest {
 
             kvCache.start();
 
-            final StopWatch stopWatch = new StopWatch();
-
-            // Make sure that we wait some duration of time for asynchronous things to occur
-            while (stopWatch.getTime() < 5000 && goodListener.getCallCount() < 1) {
-                Thread.sleep(50);
-            }
+            await().atMost(Durations.FIVE_SECONDS).until(() -> goodListener.getCallCount() > 0);
 
             Assert.assertEquals(1, goodListener.getCallCount());
         }

--- a/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
@@ -7,6 +7,8 @@ import com.orbitz.consul.monitoring.ClientEventHandler;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
+
+import org.awaitility.Durations;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -180,27 +183,25 @@ public class CacheConfigTest {
     public void testMinDelayOnEmptyResultWithNoResults() throws InterruptedException {
         TestCacheSupplier res = new TestCacheSupplier(0, Duration.ofMillis(100));
 
-        TestCache cache = TestCache.createCache(CacheConfig.builder()
+        try (TestCache cache = TestCache.createCache(CacheConfig.builder()
                 .withMinDelayOnEmptyResult(Duration.ofMillis(100))
-                .build(), res);
-        cache.start();
-        Thread.sleep(300);
-        assertTrue(res.run > 0);
-        cache.stop();
+                .build(), res)) {
+            cache.start();
+            await().atMost(Durations.FIVE_HUNDRED_MILLISECONDS).until(() -> res.run > 0);
+        }
     }
 
     @Test
     public void testMinDelayOnEmptyResultWithResults() throws InterruptedException {
         TestCacheSupplier res = new TestCacheSupplier(1, Duration.ofMillis(50));
 
-        TestCache cache = TestCache.createCache(CacheConfig.builder()
+        try (TestCache cache = TestCache.createCache(CacheConfig.builder()
                 .withMinDelayOnEmptyResult(Duration.ofMillis(100))
                 .withMinDelayBetweenRequests(Duration.ofMillis(50)) // do not blow ourselves up
-                .build(), res);
-        cache.start();
-        Thread.sleep(300);
-        assertTrue(res.run > 0);
-        cache.stop();
+                .build(), res)) {
+            cache.start();
+            await().atMost(Durations.FIVE_HUNDRED_MILLISECONDS).until(() -> res.run > 0);
+        }
     }
 
 


### PR DESCRIPTION
* Add awaitility as test-scoped dependency
* Use Awaitlity in tests where there is an easy condition to check
* Refactor serveral tests in ConsulCacheTest and CacheConfigTest to use try-with-resources

Part of #102