### PR TITLE
Replace Thread#sleep with Awaitility in ServiceHealthCacheITest

### DIFF
--- a/src/itest/java/com/orbitz/consul/Awaiting.java
+++ b/src/itest/java/com/orbitz/consul/Awaiting.java
@@ -1,0 +1,24 @@
+package com.orbitz.consul;
+
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionFactory;
+
+import java.time.Duration;
+
+/**
+ * Test utilities for using {@link Awaitility}.
+ */
+public class Awaiting {
+
+    private Awaiting() {
+        // utility class
+    }
+
+    public static ConditionFactory awaitWith25MsPoll() {
+        return awaitWithPollingMs(25);
+    }
+
+    public static ConditionFactory awaitWithPollingMs(long millis) {
+        return Awaitility.await().pollInterval(Duration.ofMillis(millis));
+    }
+}

--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -575,7 +575,7 @@ public class AgentClient extends BaseClient {
 
     /**
      * Prepends the default TTL prefix to the serviceId to produce a check id,
-     * then delegates to check(String checkId, State state, String note)
+     * then delegates to {@link #check(String, State, String)}.
      * This method only works with TTL checks that have not been given a custom
      * name.
      */


### PR DESCRIPTION
* Extract all the client.agentClient() calls into a field, intialized before each test
* Add test utility class Awaiting with factory methods to create Awaitility ConditionFactory with a poll interval smaller than the default 100ms
* Add few additional assertions in shouldNotifyListener
* Remove the 500ms pause in shouldNotifyLateListenersRaceCondition after starting the thread which adds another listener. I don't think this is necessary since weit is now using Awaitility to wait until there are two events
* These changes reduced the average test time (excluding time to setup the Consul testcontainer) from about 2.5 seconds to an average around 500-700 milliseconds.
* Add a link in the Javadoc of AgentClient#checkTtl

Part of #102