### PR TITLE
Refactor AgentITest to use Awaitility

### DIFF
--- a/src/itest/java/com/orbitz/consul/Awaiting.java
+++ b/src/itest/java/com/orbitz/consul/Awaiting.java
@@ -1,5 +1,7 @@
 package com.orbitz.consul;
 
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
 
@@ -12,6 +14,13 @@ public class Awaiting {
 
     private Awaiting() {
         // utility class
+    }
+
+    /**
+     * Awaits up to 100ms with a 25ms poll interval.
+     */
+    public static ConditionFactory awaitAtMost100ms() {
+        return awaitWith25MsPoll().atMost(ONE_HUNDRED_MILLISECONDS);
     }
 
     public static ConditionFactory awaitWith25MsPoll() {


### PR DESCRIPTION
* Replace sleeps with Awaitility
* Lots of refactoring to eliminate duplication and redundancy
* Introduce new method Awaiting#awaitAtMost100ms to further reduce duplication
* Store AgentClient in a field; initialize in setUp
* Change lots of explicit types to use 'var' where type is clear

Part of #102