### PR TITLE
Remove unnecessary FQCNs in javadocs

### DIFF
--- a/src/itest/java/com/orbitz/consul/KeyValueITest.java
+++ b/src/itest/java/com/orbitz/consul/KeyValueITest.java
@@ -307,7 +307,6 @@ public class KeyValueITest extends BaseIntegrationTest {
         String testString = "Hello World!";
         String key = "my_key";
         kvClient.putValue(key, testString);
-        // check keys (this line throws com.orbitz.consul.ConsulException: Consul request failed)
         List<String> list = kvClient.getKeys(key);
 
         assertFalse(list.isEmpty());

--- a/src/itest/java/com/orbitz/consul/cache/ServiceCatalogCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/ServiceCatalogCacheITest.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul.cache;
 
 import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.TWO_SECONDS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -8,7 +9,6 @@ import static org.junit.Assert.assertTrue;
 import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.model.catalog.CatalogService;
 
-import org.awaitility.Durations;
 import org.junit.Test;
 
 import java.util.List;
@@ -39,7 +39,7 @@ public class ServiceCatalogCacheITest extends BaseIntegrationTest {
         client.agentClient().register(20001, 20, name, serviceId1, NO_TAGS, NO_META);
         client.agentClient().register(20002, 20, name, serviceId2, NO_TAGS, NO_META);
 
-        await().atMost(Durations.ONE_SECOND).until(() -> result.size() == 3);
+        await().atMost(TWO_SECONDS).until(() -> result.size() == 3);
 
         assertEquals(0, result.get(0).size());
         assertEquals(1, result.get(1).size());

--- a/src/main/java/com/orbitz/consul/AgentClient.java
+++ b/src/main/java/com/orbitz/consul/AgentClient.java
@@ -165,7 +165,7 @@ public class AgentClient extends BaseClient {
     }
 
     /**
-     * Registers the client as a service with Consul with an existing {@link com.orbitz.consul.model.agent.Registration.RegCheck}
+     * Registers the client as a service with Consul with an existing {@link Registration.RegCheck}
      *
      * @param port  The public facing port of the service to register with Consul.
      * @param check The health check to run periodically.  Can be null.
@@ -484,7 +484,7 @@ public class AgentClient extends BaseClient {
      *
      * @param id           The service id.
      * @param queryOptions The Query Options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing {@link FullService} object.
+     * @return A {@link ConsulResponse} containing {@link FullService} object.
      */
     public ConsulResponse<FullService> getService(String id, QueryOptions queryOptions) throws NotRegisteredException {
         try {

--- a/src/main/java/com/orbitz/consul/CatalogClient.java
+++ b/src/main/java/com/orbitz/consul/CatalogClient.java
@@ -67,21 +67,19 @@ public class CatalogClient extends BaseCacheableClient {
      * <p/>
      * GET /v1/catalog/nodes
      *
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.Node} objects.
+     * @return A {@link ConsulResponse} containing a list of {@link Node} objects.
      */
     public ConsulResponse<List<Node>> getNodes() {
         return getNodes(QueryOptions.BLANK);
     }
 
     /**
-     * Retrieves all nodes for a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Retrieves all nodes for a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/catalog/nodes?dc={datacenter}
      *
      * @param queryOptions The Query Options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.Node} objects.
+     * @return A {@link ConsulResponse} containing a list of {@link Node} objects.
      */
     public ConsulResponse<List<Node>> getNodes(QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getNodes(queryOptions.toQuery(),
@@ -90,13 +88,12 @@ public class CatalogClient extends BaseCacheableClient {
     }
 
     /**
-     * Asynchronously retrieves the nodes for a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Asynchronously retrieves the nodes for a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/catalog/nodes?dc={datacenter}
      *
      * @param queryOptions The Query Options to use.
-     * @param callback     Callback implemented by callee to handle results.
-     *                     {@link com.orbitz.consul.model.health.Node} objects.
+     * @param callback     Callback implemented by callee to handle results, which are list of {@link Node} objects.
      */
     public void getNodes(QueryOptions queryOptions, ConsulResponseCallback<List<Node>> callback) {
         http.extractConsulResponse(api.getNodes(queryOptions.toQuery(), queryOptions.getTag(),
@@ -108,7 +105,7 @@ public class CatalogClient extends BaseCacheableClient {
      * <p/>
      * GET /v1/catalog/services?dc={datacenter}
      *
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a map of service name to list of tags.
+     * @return A {@link ConsulResponse} containing a map of service name to list of tags.
      */
     public ConsulResponse<Map<String, List<String>>> getServices() {
         return getServices(QueryOptions.BLANK);
@@ -120,7 +117,7 @@ public class CatalogClient extends BaseCacheableClient {
      * GET /v1/catalog/services?dc={datacenter}
      *
      * @param callback     Callback implemented by callee to handle results.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a map of service name to list of tags.
+     * @return A {@link ConsulResponse} containing a map of service name to list of tags.
      */
     public void getServices(ConsulResponseCallback<Map<String, List<String>>> callback) {
         getServices(QueryOptions.BLANK, callback);
@@ -132,7 +129,7 @@ public class CatalogClient extends BaseCacheableClient {
      * GET /v1/catalog/services?dc={datacenter}
      *
      * @param queryOptions The Query Options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a map of service name to list of tags.
+     * @return A {@link ConsulResponse} containing a map of service name to list of tags.
      */
     public ConsulResponse<Map<String, List<String>>> getServices(QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getServices(queryOptions.toQuery(),
@@ -146,7 +143,7 @@ public class CatalogClient extends BaseCacheableClient {
      *
      * @param queryOptions The Query Options to use.
      * @param callback     Callback implemented by callee to handle results.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a map of service name to list of tags.
+     * @return A {@link ConsulResponse} containing a map of service name to list of tags.
      */
     public void getServices(QueryOptions queryOptions, ConsulResponseCallback<Map<String, List<String>>> callback) {
         http.extractConsulResponse(api.getServices(queryOptions.toQuery(),
@@ -158,21 +155,19 @@ public class CatalogClient extends BaseCacheableClient {
      * <p/>
      * GET /v1/catalog/service/{service}
      *
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing
-     * {@link com.orbitz.consul.model.catalog.CatalogService} objects.
+     * @return A {@link ConsulResponse} containing {@link CatalogService} objects.
      */
     public ConsulResponse<List<CatalogService>> getService(String service) {
         return getService(service, QueryOptions.BLANK);
     }
 
     /**
-     * Retrieves a single service for a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Retrieves a single service for a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/catalog/service/{service}?dc={datacenter}
      *
      * @param queryOptions The Query Options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing
-     * {@link com.orbitz.consul.model.catalog.CatalogService} objects.
+     * @return A {@link ConsulResponse} containing {@link CatalogService} objects.
      */
     public ConsulResponse<List<CatalogService>> getService(String service, QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getService(service, queryOptions.toQuery(),
@@ -180,14 +175,14 @@ public class CatalogClient extends BaseCacheableClient {
     }
 
     /**
-     * Asynchronously retrieves the single service for a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Asynchronously retrieves the single service for a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/catalog/service/{service}?dc={datacenter}
      *
      * @param queryOptions The Query Options to use.
      * @param callback     Callback implemented by callee to handle results.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing
-     * {@link com.orbitz.consul.model.catalog.CatalogService} objects.
+     * @return A {@link ConsulResponse} containing
+     * {@link CatalogService} objects.
      */
     public void getService(String service, QueryOptions queryOptions, ConsulResponseCallback<List<CatalogService>> callback) {
         http.extractConsulResponse(api.getService(service, queryOptions.toQuery(),
@@ -199,19 +194,19 @@ public class CatalogClient extends BaseCacheableClient {
      * <p/>
      * GET /v1/catalog/node/{node}
      *
-     * @return A list of matching {@link com.orbitz.consul.model.catalog.CatalogService} objects.
+     * @return A list of matching {@link CatalogService} objects.
      */
     public ConsulResponse<CatalogNode> getNode(String node) {
         return getNode(node, QueryOptions.BLANK);
     }
 
     /**
-     * Retrieves a single node for a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Retrieves a single node for a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/catalog/node/{node}?dc={datacenter}
      *
      * @param queryOptions The Query Options to use.
-     * @return A list of matching {@link com.orbitz.consul.model.catalog.CatalogService} objects.
+     * @return A list of matching {@link CatalogService} objects.
      */
     public ConsulResponse<CatalogNode> getNode(String node, QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getNode(node, queryOptions.toQuery(),
@@ -219,7 +214,7 @@ public class CatalogClient extends BaseCacheableClient {
     }
 
     /**
-     * Asynchronously retrieves the single node for a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Asynchronously retrieves the single node for a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/catalog/node/{node}?dc={datacenter}
      *

--- a/src/main/java/com/orbitz/consul/ConsulException.java
+++ b/src/main/java/com/orbitz/consul/ConsulException.java
@@ -28,7 +28,7 @@ public class ConsulException extends RuntimeException {
      * Constructs an instance of this class.
      *
      * @param message The exception message.
-     * @param throwable The wrapped {@link java.lang.Throwable} object.
+     * @param throwable The wrapped {@link Throwable} object.
      */
     public ConsulException(String message, Throwable throwable) {
         super(message, throwable);

--- a/src/main/java/com/orbitz/consul/EventClient.java
+++ b/src/main/java/com/orbitz/consul/EventClient.java
@@ -53,7 +53,7 @@ public class EventClient extends BaseClient {
      * @param name The name of the event.
      * @param eventOptions The event specific options to use.
      * @param payload Optional string payload.
-     * @return The newly created {@link com.orbitz.consul.model.event.Event}.
+     * @return The newly created {@link Event}.
      */
     public Event fireEvent(String name, EventOptions eventOptions, String payload) {
         return http.extract(api.fireEvent(name,
@@ -67,7 +67,7 @@ public class EventClient extends BaseClient {
      * PUT /v1/event/fire/{name}
      *
      * @param name The name of the event.
-     * @return The newly created {@link com.orbitz.consul.model.event.Event}.
+     * @return The newly created {@link Event}.
      */
     public Event fireEvent(String name) {
         return fireEvent(name, EventOptions.BLANK);
@@ -80,7 +80,7 @@ public class EventClient extends BaseClient {
      *
      * @param name The name of the event.
      * @param eventOptions The event specific options to use.
-     * @return The newly created {@link com.orbitz.consul.model.event.Event}.
+     * @return The newly created {@link Event}.
      */
     public Event fireEvent(String name, EventOptions eventOptions) {
         return http.extract(api.fireEvent(name, eventOptions.toQuery()));
@@ -93,7 +93,7 @@ public class EventClient extends BaseClient {
      *
      * @param name The name of the event.
      * @param payload Optional string payload.
-     * @return The newly created {@link com.orbitz.consul.model.event.Event}.
+     * @return The newly created {@link Event}.
      */
     public Event fireEvent(String name, String payload) {
         return fireEvent(name, EventOptions.BLANK, payload);
@@ -106,8 +106,8 @@ public class EventClient extends BaseClient {
      *
      * @param name Event name to filter.
      * @param queryOptions The query options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} object containing
-     *  a list of {@link com.orbitz.consul.model.event.Event} objects.
+     * @return A {@link ConsulResponse} object containing
+     *  a list of {@link Event} objects.
      */
     public EventResponse listEvents(String name, QueryOptions queryOptions) {
         final Map<String, Object> query = queryOptions.toQuery();
@@ -125,8 +125,8 @@ public class EventClient extends BaseClient {
      * GET /v1/event/list?name={name}
      *
      * @param name Event name to filter.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} object containing
-     *  a list of {@link com.orbitz.consul.model.event.Event} objects.
+     * @return A {@link ConsulResponse} object containing
+     *  a list of {@link Event} objects.
      */
     public EventResponse listEvents(String name) {
         return listEvents(name, QueryOptions.BLANK);
@@ -138,8 +138,8 @@ public class EventClient extends BaseClient {
      * GET /v1/event/list
      *
      * @param queryOptions The query options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} object containing
-     *  a list of {@link com.orbitz.consul.model.event.Event} objects.
+     * @return A {@link ConsulResponse} object containing
+     *  a list of {@link Event} objects.
      */
     public EventResponse listEvents(QueryOptions queryOptions) {
         return listEvents(null, queryOptions);
@@ -150,8 +150,8 @@ public class EventClient extends BaseClient {
      *
      * GET /v1/event/list
      *
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} object containing
-     *  a list of {@link com.orbitz.consul.model.event.Event} objects.
+     * @return A {@link ConsulResponse} object containing
+     *  a list of {@link Event} objects.
      */
     public EventResponse listEvents() {
         return listEvents(null, QueryOptions.BLANK);

--- a/src/main/java/com/orbitz/consul/HealthClient.java
+++ b/src/main/java/com/orbitz/consul/HealthClient.java
@@ -45,22 +45,22 @@ public class HealthClient extends BaseCacheableClient {
      * GET /v1/health/node/{node}
      *
      * @param node The node to return checks for
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<HealthCheck>> getNodeChecks(String node) {
         return getNodeChecks(node, QueryOptions.BLANK);
     }
 
     /**
-     * Retrieves the healthchecks for a node in a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Retrieves the healthchecks for a node in a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/health/node/{node}?dc={datacenter}
      *
      * @param node         The node to return checks for
      * @param queryOptions The Query Options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<HealthCheck>> getNodeChecks(String node,
                                                            QueryOptions queryOptions) {
@@ -73,21 +73,21 @@ public class HealthClient extends BaseCacheableClient {
      * <p/>
      * GET /v1/health/checks/{service}
      *
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<HealthCheck>> getServiceChecks(String service) {
         return getServiceChecks(service, QueryOptions.BLANK);
     }
 
     /**
-     * Retrieves the healthchecks for a service in a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Retrieves the healthchecks for a service in a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/health/checks/{service}?dc={datacenter}
      *
      * @param queryOptions The Query Options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<HealthCheck>> getServiceChecks(String service,
                                                               QueryOptions queryOptions) {
@@ -97,14 +97,14 @@ public class HealthClient extends BaseCacheableClient {
 
     /**
      * Asynchronously retrieves the healthchecks for a service in a given
-     * datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/health/checks/{service}?dc={datacenter}
      *
      * @param service      The service to query.
      * @param queryOptions The Query Options to use.
      * @param callback     Callback implemented by callee to handle results.
-     *                     {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     *                     {@link HealthCheck} objects.
      */
     public void getServiceChecks(String service,
                                  QueryOptions queryOptions,
@@ -119,22 +119,22 @@ public class HealthClient extends BaseCacheableClient {
      * GET /v1/health/state/{state}
      *
      * @param state The state to query.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<HealthCheck>> getChecksByState(State state) {
         return getChecksByState(state, QueryOptions.BLANK);
     }
 
     /**
-     * Retrieves the healthchecks for a state in a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Retrieves the healthchecks for a state in a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/health/state/{state}?dc={datacenter}
      *
      * @param state        The state to query.
      * @param queryOptions The Query Options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<HealthCheck>> getChecksByState(State state,
                                                               QueryOptions queryOptions) {
@@ -143,15 +143,15 @@ public class HealthClient extends BaseCacheableClient {
     }
 
     /**
-     * Asynchronously retrieves the healthchecks for a state in a given datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * Asynchronously retrieves the healthchecks for a state in a given datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/health/state/{state}?dc={datacenter}
      *
      * @param state        The state to query.
      * @param queryOptions The Query Options to use.
      * @param callback     Callback implemented by callee to handle results.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public void getChecksByState(State state, QueryOptions queryOptions,
                                  ConsulResponseCallback<List<HealthCheck>> callback) {
@@ -165,8 +165,8 @@ public class HealthClient extends BaseCacheableClient {
      * GET /v1/health/service/{service}?passing
      *
      * @param service The service to query.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<ServiceHealth>> getHealthyServiceInstances(String service) {
         return getHealthyServiceInstances(service, QueryOptions.BLANK);
@@ -174,14 +174,14 @@ public class HealthClient extends BaseCacheableClient {
 
     /**
      * Retrieves the healthchecks for all healthy service instances in a given datacenter with
-     * {@link com.orbitz.consul.option.QueryOptions}.
+     * {@link QueryOptions}.
      * <p/>
      * GET /v1/health/service/{service}?dc={datacenter}&amp;passing
      *
      * @param service      The service to query.
      * @param queryOptions The Query Options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<ServiceHealth>> getHealthyServiceInstances(String service,
                                                                           QueryOptions queryOptions) {
@@ -193,7 +193,7 @@ public class HealthClient extends BaseCacheableClient {
 
     /**
      * Asynchronously retrieves the healthchecks for all healthy service instances in a given
-     * datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/health/service/{service}?dc={datacenter}&amp;passing
      * <p/>
@@ -216,8 +216,8 @@ public class HealthClient extends BaseCacheableClient {
      * GET /v1/health/service/{service}
      *
      * @param service The service to query.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<ServiceHealth>> getAllServiceInstances(String service) {
         return getAllServiceInstances(service, QueryOptions.BLANK);
@@ -225,14 +225,14 @@ public class HealthClient extends BaseCacheableClient {
 
     /**
      * Retrieves the healthchecks for all nodes in a given datacenter with
-     * {@link com.orbitz.consul.option.QueryOptions}.
+     * {@link QueryOptions}.
      * <p/>
      * GET /v1/health/service/{service}?dc={datacenter}
      *
      * @param service      The service to query.
      * @param queryOptions The Query Options to use.
-     * @return A {@link com.orbitz.consul.model.ConsulResponse} containing a list of
-     * {@link com.orbitz.consul.model.health.HealthCheck} objects.
+     * @return A {@link ConsulResponse} containing a list of
+     * {@link HealthCheck} objects.
      */
     public ConsulResponse<List<ServiceHealth>> getAllServiceInstances(String service, QueryOptions queryOptions) {
         return http.extractConsulResponse(api.getServiceInstances(service, queryOptions.toQuery(),
@@ -241,7 +241,7 @@ public class HealthClient extends BaseCacheableClient {
 
     /**
      * Asynchronously retrieves the healthchecks for all nodes in a given
-     * datacenter with {@link com.orbitz.consul.option.QueryOptions}.
+     * datacenter with {@link QueryOptions}.
      * <p/>
      * GET /v1/health/service/{service}?dc={datacenter}
      * <p/>

--- a/src/main/java/com/orbitz/consul/KeyValueClient.java
+++ b/src/main/java/com/orbitz/consul/KeyValueClient.java
@@ -72,7 +72,7 @@ public class KeyValueClient extends BaseCacheableClient {
     }
 
     /**
-     * Retrieves a {@link com.orbitz.consul.model.kv.Value} for a specific key
+     * Retrieves a {@link Value} for a specific key
      * from the key/value store.
      *
      * GET /v1/kv/{key}
@@ -85,8 +85,8 @@ public class KeyValueClient extends BaseCacheableClient {
     }
 
     /**
-     * Retrieves a {@link com.orbitz.consul.model.ConsulResponse} with the
-     * {@link com.orbitz.consul.model.kv.Value} for a spefici key from the
+     * Retrieves a {@link ConsulResponse} with the
+     * {@link Value} for a spefici key from the
      * key/value store
      * @param key The key to retrieve
      * @return An {@link Optional} containing the {@link ConsulResponse} or {@link Optional#empty()()}
@@ -96,7 +96,7 @@ public class KeyValueClient extends BaseCacheableClient {
     }
 
     /**
-     * Retrieves a {@link com.orbitz.consul.model.kv.Value} for a specific key
+     * Retrieves a {@link Value} for a specific key
      * from the key/value store.
      *
      * GET /v1/kv/{key}
@@ -151,7 +151,7 @@ public class KeyValueClient extends BaseCacheableClient {
     }
 
     /**
-     * Asynchronously retrieves a {@link com.orbitz.consul.model.kv.Value} for a specific key
+     * Asynchronously retrieves a {@link Value} for a specific key
      * from the key/value store.
      *
      * GET /v1/kv/{key}
@@ -185,13 +185,13 @@ public class KeyValueClient extends BaseCacheableClient {
     }
 
     /**
-     * Retrieves a list of {@link com.orbitz.consul.model.kv.Value} objects for a specific key
+     * Retrieves a list of {@link Value} objects for a specific key
      * from the key/value store.
      *
      * GET /v1/kv/{key}?recurse
      *
      * @param key The key to retrieve.
-     * @return A list of zero to many {@link com.orbitz.consul.model.kv.Value} objects.
+     * @return A list of zero to many {@link Value} objects.
      */
     public List<Value> getValues(String key) {
         return getValues(key, QueryOptions.BLANK);
@@ -212,14 +212,14 @@ public class KeyValueClient extends BaseCacheableClient {
     }
 
     /**
-     * Retrieves a list of {@link com.orbitz.consul.model.kv.Value} objects for a specific key
+     * Retrieves a list of {@link Value} objects for a specific key
      * from the key/value store.
      *
      * GET /v1/kv/{key}?recurse
      *
      * @param key The key to retrieve.
      * @param queryOptions The query options.
-     * @return A list of zero to many {@link com.orbitz.consul.model.kv.Value} objects.
+     * @return A list of zero to many {@link Value} objects.
      */
     public List<Value> getValues(String key, QueryOptions queryOptions) {
         Map<String, Object> query = queryOptions.toQuery();
@@ -251,7 +251,7 @@ public class KeyValueClient extends BaseCacheableClient {
     }
 
     /**
-     * Asynchronously retrieves a list of {@link com.orbitz.consul.model.kv.Value} objects for a specific key
+     * Asynchronously retrieves a list of {@link Value} objects for a specific key
      * from the key/value store.
      *
      * GET /v1/kv/{key}?recurse

--- a/src/main/java/com/orbitz/consul/async/ConsulResponseCallback.java
+++ b/src/main/java/com/orbitz/consul/async/ConsulResponseCallback.java
@@ -11,7 +11,7 @@ import com.orbitz.consul.model.ConsulResponse;
 public interface ConsulResponseCallback<T> {
 
     /**
-     * Callback for a successful {@link com.orbitz.consul.model.ConsulResponse}.
+     * Callback for a successful {@link ConsulResponse}.
      *
      * @param consulResponse The Consul response.
      */

--- a/src/main/java/com/orbitz/consul/async/EventResponseCallback.java
+++ b/src/main/java/com/orbitz/consul/async/EventResponseCallback.java
@@ -9,7 +9,7 @@ import com.orbitz.consul.model.EventResponse;
 public interface EventResponseCallback {
 
     /**
-     * Callback for a successful {@link com.orbitz.consul.model.EventResponse}.
+     * Callback for a successful {@link EventResponse}.
      *
      * @param eventResponse The Consul event response.
      */

--- a/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
+++ b/src/main/java/com/orbitz/consul/cache/HealthCheckCache.java
@@ -12,7 +12,7 @@ import java.util.function.Function;
 public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
 
     private HealthCheckCache(HealthClient healthClient,
-                             com.orbitz.consul.model.State state,
+                             com.orbitz.consul.model.State checkState,
                              int watchSeconds,
                              QueryOptions queryOptions,
                              Function<HealthCheck, String> keyExtractor,
@@ -21,11 +21,11 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
             (index, callback) -> {
                 checkWatch(healthClient.getNetworkTimeoutConfig().getClientReadTimeoutMillis(), watchSeconds);
                 QueryOptions params = watchParams(index, watchSeconds, queryOptions);
-                healthClient.getChecksByState(state, params, callback);
+                healthClient.getChecksByState(checkState, params, callback);
             },
             healthClient.getConfig().getCacheConfig(),
             healthClient.getEventHandler(),
-            new CacheDescriptor("health.state", state.getName()),
+            new CacheDescriptor("health.state", checkState.getName()),
             callbackScheduler);
     }
 
@@ -35,51 +35,51 @@ public class HealthCheckCache extends ConsulCache<String, HealthCheck> {
      * Keys will be the {@link HealthCheck#getCheckId()}.
      *
      * @param healthClient the {@link HealthClient}
-     * @param state        the state fo filter checks
+     * @param checkState   the state fo filter checks
      * @return a cache object
      */
     public static HealthCheckCache newCache(
             final HealthClient healthClient,
-            final com.orbitz.consul.model.State state,
+            final com.orbitz.consul.model.State checkState,
             final int watchSeconds,
             final QueryOptions queryOptions,
             final Function<HealthCheck, String> keyExtractor,
             final ScheduledExecutorService callbackExecutorService) {
 
         Scheduler callbackScheduler = createExternal(callbackExecutorService);
-        return new HealthCheckCache(healthClient, state, watchSeconds, queryOptions, keyExtractor, callbackScheduler);
+        return new HealthCheckCache(healthClient, checkState, watchSeconds, queryOptions, keyExtractor, callbackScheduler);
     }
 
     public static HealthCheckCache newCache(
             final HealthClient healthClient,
-            final com.orbitz.consul.model.State state,
+            final com.orbitz.consul.model.State checkState,
             final int watchSeconds,
             final QueryOptions queryOptions,
             final Function<HealthCheck, String> keyExtractor) {
 
-        return new HealthCheckCache(healthClient, state, watchSeconds, queryOptions, keyExtractor, createDefault());
+        return new HealthCheckCache(healthClient, checkState, watchSeconds, queryOptions, keyExtractor, createDefault());
     }
     public static HealthCheckCache newCache(
             final HealthClient healthClient,
-            final com.orbitz.consul.model.State state,
+            final com.orbitz.consul.model.State checkState,
             final int watchSeconds,
             final QueryOptions queryOptions) {
 
-        return newCache(healthClient, state, watchSeconds, queryOptions, HealthCheck::getCheckId);
+        return newCache(healthClient, checkState, watchSeconds, queryOptions, HealthCheck::getCheckId);
     }
 
     public static HealthCheckCache newCache(
             final HealthClient healthClient,
-            final com.orbitz.consul.model.State state,
+            final com.orbitz.consul.model.State checkState,
             final int watchSeconds) {
 
-        return newCache(healthClient, state, watchSeconds, QueryOptions.BLANK);
+        return newCache(healthClient, checkState, watchSeconds, QueryOptions.BLANK);
     }
 
-    public static HealthCheckCache newCache(final HealthClient healthClient, final com.orbitz.consul.model.State state) {
+    public static HealthCheckCache newCache(final HealthClient healthClient, final com.orbitz.consul.model.State checkState) {
         CacheConfig cacheConfig = healthClient.getConfig().getCacheConfig();
         int watchSeconds = Ints.checkedCast(cacheConfig.getWatchDuration().getSeconds());
-        return newCache(healthClient, state, watchSeconds);
+        return newCache(healthClient, checkState, watchSeconds);
     }
 
 }

--- a/src/main/java/com/orbitz/consul/model/State.java
+++ b/src/main/java/com/orbitz/consul/model/State.java
@@ -39,8 +39,7 @@ public enum State {
     }
 
     /**
-     * Returns the appropriate {@link com.orbitz.consul.model.State} given the
-     * name.
+     * Returns the appropriate {@link State} given the name.
      *
      * @param name The state name e.g. "passing".
      * @return The state.


### PR DESCRIPTION
* Remove unnecessary FQCNs in javadocs
* Also, rename "state" args in HealthCheckCache to "checkState" because the superclass ConsulCache already has a protected "state" field, which is unfortunately, and annoyingly, of a different type (the State enum defined in ConsulCache). Renaming thes arguments will make things a little more clear that the argument is the state of the health check.

Part of #107