### PR TITLE
Replace FQCN for Immutable annotation with import

### DIFF
--- a/src/main/java/com/orbitz/consul/model/kv/TxError.java
+++ b/src/main/java/com/orbitz/consul/model/kv/TxError.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
 import java.util.Optional;
 
 import java.math.BigInteger;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableTxError.class)
 @JsonSerialize(as = ImmutableTxError.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/kv/TxResponse.java
+++ b/src/main/java/com/orbitz/consul/model/kv/TxResponse.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
 
 import java.util.List;
 import java.util.Map;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableTxResponse.class)
 @JsonSerialize(as = ImmutableTxResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/kv/Value.java
+++ b/src/main/java/com/orbitz/consul/model/kv/Value.java
@@ -6,12 +6,14 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.orbitz.consul.util.UnsignedLongDeserializer;
+import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Lazy;
 
 import java.nio.charset.Charset;
 import java.util.Base64;
 import java.util.Optional;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableValue.class)
 @JsonSerialize(as = ImmutableValue.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -40,19 +42,19 @@ public abstract class Value {
     public abstract Optional<String> getSession();
 
     @JsonIgnore
-    @org.immutables.value.Value.Lazy
+    @Lazy
     public Optional<String> getValueAsString() {
         return getValueAsString(Charset.defaultCharset());
     }
 
     @JsonIgnore
-    @org.immutables.value.Value.Lazy
+    @Lazy
     public Optional<String> getValueAsString(Charset charset) {
         return getValue().map(s -> new String(Base64.getDecoder().decode(s), charset));
     }
 
     @JsonIgnore
-    @org.immutables.value.Value.Lazy
+    @Lazy
     public Optional<byte[]> getValueAsBytes() {
         return getValue().map(s -> Base64.getDecoder().decode(s));
     }

--- a/src/main/java/com/orbitz/consul/model/operator/RaftConfiguration.java
+++ b/src/main/java/com/orbitz/consul/model/operator/RaftConfiguration.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
 
 import java.math.BigInteger;
 import java.util.List;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableRaftConfiguration.class)
 @JsonSerialize(as = ImmutableRaftConfiguration.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/operator/RaftServer.java
+++ b/src/main/java/com/orbitz/consul/model/operator/RaftServer.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableRaftServer.class)
 @JsonSerialize(as = ImmutableRaftServer.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/query/DnsQuery.java
+++ b/src/main/java/com/orbitz/consul/model/query/DnsQuery.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableDnsQuery.class)
 @JsonSerialize(as = ImmutableDnsQuery.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/query/Failover.java
+++ b/src/main/java/com/orbitz/consul/model/query/Failover.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
 
 import java.util.List;
 import java.util.Optional;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableFailover.class)
 @JsonSerialize(as = ImmutableFailover.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/query/PreparedQuery.java
+++ b/src/main/java/com/orbitz/consul/model/query/PreparedQuery.java
@@ -4,14 +4,16 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
+
 import java.util.Optional;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutablePreparedQuery.class)
 @JsonSerialize(as = ImmutablePreparedQuery.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class PreparedQuery {
-    
+
     @JsonProperty("Template")
     public abstract Optional<Template> getTemplate();
 

--- a/src/main/java/com/orbitz/consul/model/query/QueryId.java
+++ b/src/main/java/com/orbitz/consul/model/query/QueryId.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableQueryId.class)
 @JsonSerialize(as = ImmutableQueryId.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/query/RaftIndex.java
+++ b/src/main/java/com/orbitz/consul/model/query/RaftIndex.java
@@ -3,8 +3,9 @@ package com.orbitz.consul.model.query;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableRaftIndex.class)
 @JsonSerialize(as = ImmutableRaftIndex.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/query/ServiceQuery.java
+++ b/src/main/java/com/orbitz/consul/model/query/ServiceQuery.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Optional;
+import org.immutables.value.Value.Immutable;
 
+import java.util.Optional;
 import java.util.List;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableServiceQuery.class)
 @JsonSerialize(as = ImmutableServiceQuery.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/query/StoredQuery.java
+++ b/src/main/java/com/orbitz/consul/model/query/StoredQuery.java
@@ -4,8 +4,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableStoredQuery.class)
 @JsonSerialize(as = ImmutableStoredQuery.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/com/orbitz/consul/model/query/Template.java
+++ b/src/main/java/com/orbitz/consul/model/query/Template.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value.Immutable;
+
 import java.util.Optional;
 
-@org.immutables.value.Value.Immutable
+@Immutable
 @JsonDeserialize(as = ImmutableTemplate.class)
 @JsonSerialize(as = ImmutableTemplate.class)
 @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
Instead of having the FQCN (@org.immutables.value.Value.Immutable) on top of models with an import and just @Immutable

Part of #107