### PR TITLE
Add test utility to easily create random UUIDs

### DIFF
--- a/src/itest/java/com/orbitz/consul/AclTest.java
+++ b/src/itest/java/com/orbitz/consul/AclTest.java
@@ -1,5 +1,13 @@
 package com.orbitz.consul;
 
+import static com.orbitz.consul.TestUtils.randomUUIDString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.model.acl.ImmutablePolicy;
 import com.orbitz.consul.model.acl.ImmutablePolicyLink;
@@ -13,21 +21,12 @@ import com.orbitz.consul.model.acl.TokenResponse;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.testcontainers.containers.GenericContainer;
 
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.IsNot.not;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-
-import org.testcontainers.containers.GenericContainer;
 
 public class AclTest {
 
@@ -73,7 +72,7 @@ public class AclTest {
     public void testCreateAndReadPolicy() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse policy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
         assertThat(policy.name(), is(policyName));
         assertThat(policy.datacenters(), is(Optional.empty()));
@@ -87,7 +86,7 @@ public class AclTest {
     public void testCreateAndReadPolicy_WithDatacenters() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         ImmutablePolicy newPolicy = ImmutablePolicy.builder().name(policyName).datacenters(List.of("dc1")).build();
         PolicyResponse policy = aclClient.createPolicy(newPolicy);
         assertThat(policy.name(), is(policyName));
@@ -102,7 +101,7 @@ public class AclTest {
     public void testCreateAndReadPolicyByName() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse policy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
         assertThat(policy.name(), is(policyName));
 
@@ -114,10 +113,10 @@ public class AclTest {
     public void testUpdatePolicy() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse createdPolicy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
 
-        String newPolicyName = UUID.randomUUID().toString();
+        String newPolicyName = randomUUIDString();
         aclClient.updatePolicy(createdPolicy.id(), ImmutablePolicy.builder().name(newPolicyName).build());
 
         PolicyResponse updatedPolicy = aclClient.readPolicy(createdPolicy.id());
@@ -128,7 +127,7 @@ public class AclTest {
     public void testDeletePolicy() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse createdPolicy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
 
         int oldPolicyCount = aclClient.listPolicies().size();
@@ -142,10 +141,10 @@ public class AclTest {
     public void testCreateAndReadToken() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse createdPolicy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
 
-        String tokenDescription = UUID.randomUUID().toString();
+        String tokenDescription = randomUUIDString();
         TokenResponse createdToken = aclClient.createToken(ImmutableToken.builder().description(tokenDescription).local(false).addPolicies(ImmutablePolicyLink.builder().id(createdPolicy.id()).build()).build());
 
         TokenResponse readToken = aclClient.readToken(createdToken.accessorId());
@@ -158,10 +157,10 @@ public class AclTest {
     public void testCreateAndCloneTokenWithNewDescription() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse createdPolicy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
 
-        String tokenDescription = UUID.randomUUID().toString();
+        String tokenDescription = randomUUIDString();
         TokenResponse createdToken = aclClient.createToken(
                 ImmutableToken.builder()
                         .description(tokenDescription)
@@ -172,7 +171,7 @@ public class AclTest {
                                         .build()
                         ).build());
 
-        String updatedTokenDescription = UUID.randomUUID().toString();
+        String updatedTokenDescription = randomUUIDString();
         Token updateToken =
                 ImmutableToken.builder()
                         .id(createdToken.accessorId())
@@ -189,11 +188,11 @@ public class AclTest {
     public void testCreateAndReadTokenWithCustomIds() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse createdPolicy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
 
-        String tokenId = UUID.randomUUID().toString();
-        String tokenSecretId = UUID.randomUUID().toString();
+        String tokenId = randomUUIDString();
+        String tokenSecretId = randomUUIDString();
         Token token = ImmutableToken.builder()
                 .id(tokenId)
                 .secretId(tokenSecretId)
@@ -223,7 +222,7 @@ public class AclTest {
     public void testUpdateToken() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse createdPolicy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
 
         ImmutableToken newToken = ImmutableToken.builder()
@@ -233,7 +232,7 @@ public class AclTest {
                 .build();
         TokenResponse createdToken = aclClient.createToken(newToken);
 
-        String newDescription = UUID.randomUUID().toString();
+        String newDescription = randomUUIDString();
         ImmutableToken tokenUpdates = ImmutableToken.builder()
                 .id(createdToken.accessorId())
                 .local(false)
@@ -258,9 +257,9 @@ public class AclTest {
     public void testDeleteToken() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse createdPolicy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
-        TokenResponse createdToken = aclClient.createToken(ImmutableToken.builder().description(UUID.randomUUID().toString()).local(false).addPolicies(ImmutablePolicyLink.builder().id(createdPolicy.id()).build()).build());
+        TokenResponse createdToken = aclClient.createToken(ImmutableToken.builder().description(randomUUIDString()).local(false).addPolicies(ImmutablePolicyLink.builder().id(createdPolicy.id()).build()).build());
 
         int oldTokenCount = aclClient.listTokens().size();
         aclClient.deleteToken(createdToken.accessorId());
@@ -273,8 +272,8 @@ public class AclTest {
     public void testListRoles() {
         AclClient aclClient = client.aclClient();
 
-        String roleName1 = UUID.randomUUID().toString();
-        String roleName2 = UUID.randomUUID().toString();
+        String roleName1 = randomUUIDString();
+        String roleName2 = randomUUIDString();
         aclClient.createRole(ImmutableRole.builder().name(roleName1).build());
         aclClient.createRole(ImmutableRole.builder().name(roleName2).build());
 
@@ -286,7 +285,7 @@ public class AclTest {
     public void testCreateAndReadRole() {
         AclClient aclClient = client.aclClient();
 
-        String roleName = UUID.randomUUID().toString();
+        String roleName = randomUUIDString();
         RoleResponse role = aclClient.createRole(ImmutableRole.builder().name(roleName).build());
 
         RoleResponse roleResponse = aclClient.readRole(role.id());
@@ -297,7 +296,7 @@ public class AclTest {
     public void testCreateAndReadRoleByName() {
         AclClient aclClient = client.aclClient();
 
-        String roleName = UUID.randomUUID().toString();
+        String roleName = randomUUIDString();
         RoleResponse role = aclClient.createRole(ImmutableRole.builder().name(roleName).build());
 
         RoleResponse roleResponse = aclClient.readRoleByName(role.name());
@@ -308,10 +307,10 @@ public class AclTest {
     public void testCreateAndReadRoleWithPolicy() {
         AclClient aclClient = client.aclClient();
 
-        String policyName = UUID.randomUUID().toString();
+        String policyName = randomUUIDString();
         PolicyResponse createdPolicy = aclClient.createPolicy(ImmutablePolicy.builder().name(policyName).build());
 
-        String roleName = UUID.randomUUID().toString();
+        String roleName = randomUUIDString();
         RoleResponse role = aclClient.createRole(
                 ImmutableRole.builder()
                         .name(roleName)
@@ -333,8 +332,8 @@ public class AclTest {
     public void testUpdateRole() {
         AclClient aclClient = client.aclClient();
 
-        String roleName = UUID.randomUUID().toString();
-        String roleDescription = UUID.randomUUID().toString();
+        String roleName = randomUUIDString();
+        String roleDescription = randomUUIDString();
         RoleResponse role = aclClient.createRole(
                 ImmutableRole.builder()
                         .name(roleName)
@@ -344,7 +343,7 @@ public class AclTest {
         RoleResponse roleResponse = aclClient.readRole(role.id());
         assertEquals(roleDescription, roleResponse.description());
 
-        String roleNewDescription = UUID.randomUUID().toString();
+        String roleNewDescription = randomUUIDString();
         RoleResponse updatedRoleResponse = aclClient.updateRole(roleResponse.id(),
                 ImmutableRole.builder()
                         .name(roleName)
@@ -358,7 +357,7 @@ public class AclTest {
     public void testDeleteRole() {
         AclClient aclClient = client.aclClient();
 
-        String roleName = UUID.randomUUID().toString();
+        String roleName = randomUUIDString();
         RoleResponse role = aclClient.createRole(
                 ImmutableRole.builder()
                         .name(roleName)

--- a/src/itest/java/com/orbitz/consul/AgentITest.java
+++ b/src/itest/java/com/orbitz/consul/AgentITest.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul;
 
 import static com.orbitz.consul.Awaiting.awaitAtMost100ms;
+import static com.orbitz.consul.TestUtils.randomUUIDString;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.AnyOf.anyOf;
@@ -25,6 +26,7 @@ import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.ImmutableQueryParameterOptions;
 import com.orbitz.consul.option.QueryOptions;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -34,7 +36,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -70,8 +71,8 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterTtlCheck() {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
 
         agentClient.register(8080, 10000L, serviceName, serviceId, NO_TAGS, NO_META);
 
@@ -84,8 +85,8 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterHttpCheck() throws MalformedURLException {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
 
         var healthCheclkUrl = URI.create("http://localhost:1337/health").toURL();
         agentClient.register(8080, healthCheclkUrl, 1000L, serviceName, serviceId, NO_TAGS, NO_META);
@@ -99,8 +100,8 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterGrpcCheck() {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
 
         var registration = ImmutableRegistration.builder()
                 .name(serviceName)
@@ -122,9 +123,9 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterCheckWithId() {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
-        var checkId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var checkId = randomUUIDString();
 
         var registration = ImmutableRegistration.builder()
                 .name(serviceName)
@@ -148,9 +149,9 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterCheckWithName() {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
-        var checkName = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var checkName = randomUUIDString();
 
         var registration = ImmutableRegistration.builder()
                 .name(serviceName)
@@ -174,8 +175,8 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterMultipleChecks() {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
 
         var regChecks = List.of(
                 Registration.RegCheck.args(List.of("/usr/bin/echo \"sup\""), 10, 1, "Custom description."),
@@ -195,8 +196,8 @@ public class AgentITest extends BaseIntegrationTest {
     // and multiple "Checks" in one call
     @Test
     public void shouldRegisterMultipleChecks2() {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
 
         var singleCheck = Registration.RegCheck.args(List.of("/usr/bin/echo \"sup\""), 10);
 
@@ -221,8 +222,8 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterChecksFromCleanState() {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
 
         var regChecks = List.of(
                 Registration.RegCheck.args(List.of("/usr/bin/echo \"sup\""), 10, 1, "Custom description."),
@@ -266,8 +267,8 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldDeregister() {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
 
         agentClient.register(8080, 10000L, serviceName, serviceId, NO_TAGS, NO_META);
         agentClient.deregister(serviceId);
@@ -277,8 +278,8 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldGetChecks() {
-        var serviceId = UUID.randomUUID().toString();
-        var serviceName = UUID.randomUUID().toString();
+        var serviceId = randomUUIDString();
+        var serviceName = randomUUIDString();
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
 
         awaitAtMost100ms().until(() -> checkExistsWithId("service:" + serviceId));
@@ -286,10 +287,10 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldGetServices() {
-        var serviceId = UUID.randomUUID().toString();
-        var serviceName = UUID.randomUUID().toString();
-        var tags = List.of(UUID.randomUUID().toString());
-        var meta = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        var serviceId = randomUUIDString();
+        var serviceName = randomUUIDString();
+        var tags = List.of(randomUUIDString());
+        var meta = Map.of(randomUUIDString(), randomUUIDString());
 
         agentClient.register(8080, 20L, serviceName, serviceId, tags, meta);
 
@@ -312,11 +313,11 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldGetServicesFiltered() {
-        var serviceId = UUID.randomUUID().toString();
-        var serviceName = UUID.randomUUID().toString();
-        var tags = List.of(UUID.randomUUID().toString());
+        var serviceId = randomUUIDString();
+        var serviceName = randomUUIDString();
+        var tags = List.of(randomUUIDString());
         var metaKey = "MetaKey";
-        var metaValue = UUID.randomUUID().toString();
+        var metaValue = randomUUIDString();
         var meta = Map.of(metaKey, metaValue);
 
         agentClient.register(8080, 20L, serviceName, serviceId, tags, meta);
@@ -345,10 +346,10 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldGetService() throws NotRegisteredException {
-        var serviceId = UUID.randomUUID().toString();
-        var serviceName = UUID.randomUUID().toString();
-        var tags = List.of(UUID.randomUUID().toString());
-        var meta = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        var serviceId = randomUUIDString();
+        var serviceName = randomUUIDString();
+        var tags = List.of(randomUUIDString());
+        var meta = Map.of(randomUUIDString(), randomUUIDString());
 
         agentClient.register(8080, 20L, serviceName, serviceId, tags, meta);
 
@@ -373,10 +374,10 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldGetServiceWithWait() throws NotRegisteredException {
-        var serviceId = UUID.randomUUID().toString();
-        var serviceName = UUID.randomUUID().toString();
-        var tags = List.of(UUID.randomUUID().toString());
-        var meta = Map.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());
+        var serviceId = randomUUIDString();
+        var serviceName = randomUUIDString();
+        var tags = List.of(randomUUIDString());
+        var meta = Map.of(randomUUIDString(), randomUUIDString());
 
         var ttl = 2;  // seconds
         agentClient.register(8080, ttl, serviceName, serviceId, tags, meta);
@@ -398,14 +399,14 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test(expected = NotRegisteredException.class)
     public void shouldGetServiceThrowErrorWhenServiceIsUnknown() throws NotRegisteredException {
-        agentClient.getService(UUID.randomUUID().toString(), QueryOptions.BLANK);
+        agentClient.getService(randomUUIDString(), QueryOptions.BLANK);
     }
 
     @Test
     public void shouldSetWarning() throws NotRegisteredException {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
-        var note = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var note = randomUUIDString();
 
         agentClient.register(8080, 20L, serviceName, serviceId, List.of(), Map.of());
 
@@ -418,9 +419,9 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldSetFailing() throws NotRegisteredException {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
-        var note = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var note = randomUUIDString();
 
         agentClient.register(8080, 20L, serviceName, serviceId, List.of(), Map.of());
 
@@ -433,7 +434,7 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterNodeScriptCheck() {
-        var checkId = UUID.randomUUID().toString();
+        var checkId = randomUUIDString();
 
         agentClient.registerCheck(checkId, "test-validate", "/usr/bin/echo \"sup\"", 30);
 
@@ -451,7 +452,7 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterNodeHttpCheck() throws MalformedURLException {
-        var checkId = UUID.randomUUID().toString();
+        var checkId = randomUUIDString();
 
         var healthCheckUrl = URI.create("http://foo.local:1337/check").toURL();
         agentClient.registerCheck(checkId, "test-validate", healthCheckUrl, 30);
@@ -470,7 +471,7 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterNodeTtlCheck() {
-        var checkId = UUID.randomUUID().toString();
+        var checkId = randomUUIDString();
 
         agentClient.registerCheck(checkId, "test-validate", 30);
 
@@ -488,9 +489,9 @@ public class AgentITest extends BaseIntegrationTest {
 
     @Test
     public void shouldEnableMaintenanceMode() {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
-        var reason = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var reason = randomUUIDString();
 
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
 

--- a/src/itest/java/com/orbitz/consul/BaseIntegrationTest.java
+++ b/src/itest/java/com/orbitz/consul/BaseIntegrationTest.java
@@ -1,8 +1,11 @@
 package com.orbitz.consul;
 
+import static com.orbitz.consul.TestUtils.randomUUIDString;
+
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.config.ClientConfig;
+
 import org.junit.After;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
@@ -11,7 +14,6 @@ import org.testcontainers.containers.GenericContainer;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 public abstract class BaseIntegrationTest {
@@ -85,7 +87,7 @@ public abstract class BaseIntegrationTest {
     }
 
     protected String createAutoDeregisterServiceId() {
-        String serviceId = UUID.randomUUID().toString();
+        String serviceId = randomUUIDString();
         LOG.info("Created auto-deregister serviceId {}", serviceId);
         deregisterServices.add(serviceId);
 

--- a/src/itest/java/com/orbitz/consul/CatalogITest.java
+++ b/src/itest/java/com/orbitz/consul/CatalogITest.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul;
 
 import static com.orbitz.consul.Awaiting.awaitWith25MsPoll;
+import static com.orbitz.consul.TestUtils.randomUUIDString;
 import static java.util.Objects.nonNull;
 import static org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
 import static org.junit.Assert.assertEquals;
@@ -31,7 +32,6 @@ import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -136,9 +136,9 @@ public class CatalogITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterService() {
-        String service = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
-        String catalogId = UUID.randomUUID().toString();
+        String service = randomUUIDString();
+        String serviceId = randomUUIDString();
+        String catalogId = randomUUIDString();
 
         createAndCheckService(
                 ImmutableCatalogService.builder()
@@ -177,9 +177,9 @@ public class CatalogITest extends BaseIntegrationTest {
 
     @Test
     public void shouldRegisterServiceNoWeights() {
-        String service = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
-        String catalogId = UUID.randomUUID().toString();
+        String service = randomUUIDString();
+        String serviceId = randomUUIDString();
+        String catalogId = randomUUIDString();
 
         createAndCheckService(
                 ImmutableCatalogService.builder()
@@ -218,9 +218,9 @@ public class CatalogITest extends BaseIntegrationTest {
 
     @Test
     public void shouldDeregisterWithDefaultDC() throws InterruptedException {
-        String service = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
-        String catalogId = UUID.randomUUID().toString();
+        String service = randomUUIDString();
+        String serviceId = randomUUIDString();
+        String catalogId = randomUUIDString();
 
         CatalogRegistration registration = ImmutableCatalogRegistration.builder()
                 .id(catalogId)
@@ -265,7 +265,7 @@ public class CatalogITest extends BaseIntegrationTest {
 
     @Test
     public void shouldGetServicesInCallback() throws ExecutionException, InterruptedException, TimeoutException {
-        String serviceName = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
         String serviceId = createAutoDeregisterServiceId();
         client.agentClient().register(20001, 20, serviceName, serviceId, List.of(), Map.of());
 
@@ -279,7 +279,7 @@ public class CatalogITest extends BaseIntegrationTest {
 
     @Test
     public void shouldGetServiceInCallback() throws ExecutionException, InterruptedException, TimeoutException {
-        String serviceName = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
         String serviceId = createAutoDeregisterServiceId();
         client.agentClient().register(20001, 20, serviceName, serviceId, List.of(), Map.of());
 
@@ -297,9 +297,9 @@ public class CatalogITest extends BaseIntegrationTest {
     @Test
     public void shouldGetNodeInCallback() throws ExecutionException, InterruptedException, TimeoutException {
         String nodeName = "node";
-        String serviceName = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
-        String catalogId = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
+        String serviceId = randomUUIDString();
+        String catalogId = randomUUIDString();
 
         CatalogRegistration registration = ImmutableCatalogRegistration.builder()
                 .id(catalogId)

--- a/src/itest/java/com/orbitz/consul/HealthITest.java
+++ b/src/itest/java/com/orbitz/consul/HealthITest.java
@@ -1,5 +1,10 @@
 package com.orbitz.consul;
 
+import static com.orbitz.consul.Consul.builder;
+import static com.orbitz.consul.TestUtils.randomUUIDString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.model.State;
@@ -9,17 +14,13 @@ import com.orbitz.consul.model.health.HealthCheck;
 import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.QueryOptions;
+
 import org.junit.Test;
 
 import java.math.BigInteger;
 import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-
-import static com.orbitz.consul.Consul.builder;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class HealthITest extends BaseIntegrationTest {
 
@@ -28,14 +29,14 @@ public class HealthITest extends BaseIntegrationTest {
 
     @Test
     public void shouldFetchPassingNode() throws NotRegisteredException {
-        String serviceName = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
+        String serviceId = randomUUIDString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
 
         Consul client2 = builder().withHostAndPort(HostAndPort.fromParts("localhost", consulContainer.getFirstMappedPort())).build();
-        String serviceId2 = UUID.randomUUID().toString();
+        String serviceId2 = randomUUIDString();
 
         client2.agentClient().register(8080, 20L, serviceName, serviceId2, NO_TAGS, NO_META);
         client2.agentClient().fail(serviceId2);
@@ -49,8 +50,8 @@ public class HealthITest extends BaseIntegrationTest {
 
     @Test
     public void shouldFetchNode() throws UnknownHostException, NotRegisteredException {
-        String serviceName = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
+        String serviceId = randomUUIDString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
@@ -63,8 +64,8 @@ public class HealthITest extends BaseIntegrationTest {
 
     @Test
     public void shouldFetchNodeDatacenter() throws UnknownHostException, NotRegisteredException {
-        String serviceName = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
+        String serviceId = randomUUIDString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
@@ -77,8 +78,8 @@ public class HealthITest extends BaseIntegrationTest {
 
     @Test
     public void shouldFetchNodeBlock() throws UnknownHostException, NotRegisteredException {
-        String serviceName = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
+        String serviceId = randomUUIDString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().pass(serviceId);
@@ -91,8 +92,8 @@ public class HealthITest extends BaseIntegrationTest {
 
     @Test
     public void shouldFetchChecksForServiceBlock() throws UnknownHostException, NotRegisteredException {
-        String serviceName = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
+        String serviceId = randomUUIDString();
 
         Registration.RegCheck check = Registration.RegCheck.ttl(5);
         Registration registration = ImmutableRegistration
@@ -123,8 +124,8 @@ public class HealthITest extends BaseIntegrationTest {
 
     @Test
     public void shouldFetchByState() throws UnknownHostException, NotRegisteredException {
-        String serviceName = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
+        String serviceId = randomUUIDString();
 
         client.agentClient().register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         client.agentClient().warn(serviceId);

--- a/src/itest/java/com/orbitz/consul/KeyValueITest.java
+++ b/src/itest/java/com/orbitz/consul/KeyValueITest.java
@@ -1,8 +1,11 @@
 package com.orbitz.consul;
 
-import java.nio.charset.Charset;
-import java.util.Optional;
-import java.util.Set;
+import static com.orbitz.consul.TestUtils.randomUUIDString;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
@@ -14,17 +17,21 @@ import com.orbitz.consul.model.session.ImmutableSession;
 import com.orbitz.consul.model.session.SessionCreatedResponse;
 import com.orbitz.consul.option.ConsistencyMode;
 import com.orbitz.consul.option.ImmutableDeleteOptions;
-import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.ImmutableDeleteOptions.Builder;
+import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.PutOptions;
 import com.orbitz.consul.option.QueryOptions;
+
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Test;
 
 import java.net.UnknownHostException;
+import java.nio.charset.Charset;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ThreadLocalRandom;
@@ -32,20 +39,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 public class KeyValueITest extends BaseIntegrationTest {
     private static final Charset TEST_CHARSET = Charset.forName("IBM297");
 
     @Test
     public void shouldPutAndReceiveString() throws UnknownHostException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
 
         assertTrue(keyValueClient.putValue(key, value));
         assertEquals(value, keyValueClient.getValueAsString(key).get());
@@ -54,8 +55,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldPutAndReceiveStringWithAnotherCharset() throws UnknownHostException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
 
         assertTrue(keyValueClient.putValue(key, value, TEST_CHARSET));
         assertEquals(value, keyValueClient.getValueAsString(key, TEST_CHARSET).get());
@@ -64,8 +65,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldPutAndReceiveValue() throws UnknownHostException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
 
         assertTrue(keyValueClient.putValue(key, value));
         Value received = keyValueClient.getValue(key).get();
@@ -76,8 +77,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldPutAndReceiveValueWithAnotherCharset() throws UnknownHostException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
 
         assertTrue(keyValueClient.putValue(key, value, TEST_CHARSET));
         Value received = keyValueClient.getValue(key).get();
@@ -88,8 +89,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldPutAndReceiveWithFlags() throws UnknownHostException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
         long flags = UUID.randomUUID().getMostSignificantBits();
 
         assertTrue(keyValueClient.putValue(key, value, flags));
@@ -101,8 +102,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldPutAndReceiveWithFlagsAndCharset() throws UnknownHostException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
         long flags = UUID.randomUUID().getMostSignificantBits();
 
         assertTrue(keyValueClient.putValue(key, value, flags, TEST_CHARSET));
@@ -114,7 +115,7 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void putNullValue() {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
 
         assertTrue(keyValueClient.putValue(key));
 
@@ -125,7 +126,7 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void putNullValueWithAnotherCharset() {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
 
         assertTrue(keyValueClient.putValue(key, null, 0, PutOptions.BLANK, TEST_CHARSET));
 
@@ -139,7 +140,7 @@ public class KeyValueITest extends BaseIntegrationTest {
         byte[] value = new byte[256];
         ThreadLocalRandom.current().nextBytes(value);
 
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
 
         assertTrue(keyValueClient.putValue(key, value, 0, PutOptions.BLANK));
 
@@ -155,10 +156,10 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldPutAndReceiveStrings() throws UnknownHostException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String key2 = key + "/" + UUID.randomUUID().toString();
-        final String value = UUID.randomUUID().toString();
-        final String value2 = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String key2 = key + "/" + randomUUIDString();
+        final String value = randomUUIDString();
+        final String value2 = randomUUIDString();
 
         assertTrue(keyValueClient.putValue(key, value));
         assertTrue(keyValueClient.putValue(key2, value2));
@@ -168,10 +169,10 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldPutAndReceiveStringsWithAnotherCharset() throws UnknownHostException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String key2 = key + "/" + UUID.randomUUID().toString();
-        final String value = UUID.randomUUID().toString();
-        final String value2 = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String key2 = key + "/" + randomUUIDString();
+        final String value = randomUUIDString();
+        final String value2 = randomUUIDString();
 
         assertTrue(keyValueClient.putValue(key, value, TEST_CHARSET));
         assertTrue(keyValueClient.putValue(key2, value2, TEST_CHARSET));
@@ -181,8 +182,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldDelete() throws Exception {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        final String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        final String value = randomUUIDString();
 
         keyValueClient.putValue(key, value);
         assertTrue(keyValueClient.getValueAsString(key).isPresent());
@@ -195,10 +196,10 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldDeleteRecursively() throws Exception {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String childKEY = key + "/" + UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String childKEY = key + "/" + randomUUIDString();
 
-        final String value = UUID.randomUUID().toString();
+        final String value = randomUUIDString();
 
         keyValueClient.putValue(key);
         keyValueClient.putValue(childKEY, value);
@@ -214,8 +215,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void shouldDeleteCas() throws Exception {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        final String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        final String value = randomUUIDString();
 
         /**
          * Update the value twice and remember the value at each step
@@ -226,7 +227,7 @@ public class KeyValueITest extends BaseIntegrationTest {
         assertTrue(valueAfter1stPut.isPresent());
         assertTrue(valueAfter1stPut.get().getValueAsString().isPresent());
 
-        keyValueClient.putValue(key, UUID.randomUUID().toString());
+        keyValueClient.putValue(key, randomUUIDString());
 
         final Optional<Value> valueAfter2ndPut = keyValueClient.getValue(key);
         assertTrue(valueAfter2ndPut.isPresent());
@@ -259,8 +260,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     public void acquireAndReleaseLock() throws Exception {
         KeyValueClient keyValueClient = client.keyValueClient();
         SessionClient sessionClient = client.sessionClient();
-        String key = UUID.randomUUID().toString();
-        String value = "session_" + UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = "session_" + randomUUIDString();
         SessionCreatedResponse response = sessionClient.createSession(ImmutableSession.builder().name(value).build());
         String sessionId = response.getId();
 
@@ -282,13 +283,13 @@ public class KeyValueITest extends BaseIntegrationTest {
         KeyValueClient keyValueClient = client.keyValueClient();
         SessionClient sessionClient = client.sessionClient();
 
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
         keyValueClient.putValue(key, value);
 
         assertEquals(false, keyValueClient.getSession(key).isPresent());
 
-        String sessionValue = "session_" + UUID.randomUUID().toString();
+        String sessionValue = "session_" + randomUUIDString();
         SessionCreatedResponse response = sessionClient.createSession(ImmutableSession.builder().name(sessionValue).build());
         String sessionId = response.getId();
 
@@ -318,17 +319,17 @@ public class KeyValueITest extends BaseIntegrationTest {
         KeyValueClient keyValueClient = client.keyValueClient();
         SessionClient sessionClient = client.sessionClient();
 
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
         keyValueClient.putValue(key, value);
 
         assertEquals(false, keyValueClient.getSession(key).isPresent());
 
-        String sessionValue = "session_" + UUID.randomUUID().toString();
+        String sessionValue = "session_" + randomUUIDString();
         SessionCreatedResponse response = sessionClient.createSession(ImmutableSession.builder().name(sessionValue).build());
         String sessionId = response.getId();
 
-        String sessionValue2 = "session_" + UUID.randomUUID().toString();
+        String sessionValue2 = "session_" + randomUUIDString();
         SessionCreatedResponse response2 = sessionClient.createSession(ImmutableSession.builder().name(sessionValue).build());
         String sessionId2 = response2.getId();
 
@@ -354,8 +355,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void testGetValuesAsync() throws InterruptedException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
         keyValueClient.putValue(key, value);
 
         final CountDownLatch completed = new CountDownLatch(1);
@@ -382,8 +383,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void testGetConsulResponseWithValue() {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
         keyValueClient.putValue(key, value);
 
         Optional<ConsulResponse<Value>> response = keyValueClient.getConsulResponseWithValue(key);
@@ -398,8 +399,8 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void testGetConsulResponseWithValues() {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
-        String value = UUID.randomUUID().toString();
+        String key = randomUUIDString();
+        String value = randomUUIDString();
         keyValueClient.putValue(key, value);
 
         ConsulResponse<List<Value>> response = keyValueClient.getConsulResponseWithValues(key);
@@ -413,7 +414,7 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void testGetValueNotFoundAsync() throws InterruptedException {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
 
         final int numTests = 2;
         final CountDownLatch completed = new CountDownLatch(numTests);
@@ -461,7 +462,7 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void testBasicTxn() throws Exception {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
         String value = Base64.encodeBase64String(RandomStringUtils.random(20).getBytes());
         Operation[] operation = new Operation[] {ImmutableOperation.builder().verb("set")
                 .key(key)
@@ -476,7 +477,7 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void testBasicTxn_Deprecated_Using_DEFAULT_ConsistencyMode() throws Exception {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
         String value = Base64.encodeBase64String(RandomStringUtils.random(20).getBytes());
         Operation[] operation = new Operation[] {ImmutableOperation.builder().verb("set")
                 .key(key)
@@ -491,7 +492,7 @@ public class KeyValueITest extends BaseIntegrationTest {
     @Test
     public void testBasicTxn_Deprecated_Using_CONSISTENT_ConsistencyMode() throws Exception {
         KeyValueClient keyValueClient = client.keyValueClient();
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
         String value = Base64.encodeBase64String(RandomStringUtils.random(20).getBytes());
         Operation[] operation = new Operation[] {ImmutableOperation.builder().verb("set")
                 .key(key)

--- a/src/itest/java/com/orbitz/consul/PreparedQueryITest.java
+++ b/src/itest/java/com/orbitz/consul/PreparedQueryITest.java
@@ -1,10 +1,6 @@
 package com.orbitz.consul;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
+import static com.orbitz.consul.TestUtils.randomUUIDString;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -22,7 +18,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.UUID;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class PreparedQueryITest extends BaseIntegrationTest {
 
@@ -42,8 +41,8 @@ public class PreparedQueryITest extends BaseIntegrationTest {
 
     @Test
     public void shouldCreateAndFindPreparedQuery() {
-        var serviceName = UUID.randomUUID().toString();
-        var query = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var query = randomUUIDString();
         client.agentClient().register(8080, 10000L, serviceName, serviceName + "1", List.of(), Map.of());
 
         var preparedQuery = ImmutablePreparedQuery.builder()
@@ -70,8 +69,8 @@ public class PreparedQueryITest extends BaseIntegrationTest {
 
     @Test
     public void shouldCreatePreparedQueryWithFailoverProperties() {
-        var serviceName = UUID.randomUUID().toString();
-        var query = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var query = randomUUIDString();
         client.agentClient().register(8080, 10000L, serviceName, serviceName + "1", List.of(), Map.of());
 
         var preparedQuery = ImmutablePreparedQuery.builder()
@@ -106,12 +105,12 @@ public class PreparedQueryITest extends BaseIntegrationTest {
 
     @Test
     public void shouldListPreparedQueries() {
-        var serviceName1 = UUID.randomUUID().toString();
-        var query1 = UUID.randomUUID().toString();
+        var serviceName1 = randomUUIDString();
+        var query1 = randomUUIDString();
         client.agentClient().register(8080, 10000L, serviceName1, serviceName1 + "_id", List.of(), Map.of());
 
-        var serviceName2 = UUID.randomUUID().toString();
-        var query2 = UUID.randomUUID().toString();
+        var serviceName2 = randomUUIDString();
+        var query2 = randomUUIDString();
         client.agentClient().register(8080, 10000L, serviceName2, serviceName2 + "_id", List.of(), Map.of());
 
         var preparedQuery1 = ImmutablePreparedQuery.builder()

--- a/src/itest/java/com/orbitz/consul/SessionClientITest.java
+++ b/src/itest/java/com/orbitz/consul/SessionClientITest.java
@@ -1,19 +1,20 @@
 package com.orbitz.consul;
 
-import com.orbitz.consul.model.session.ImmutableSession;
-import com.orbitz.consul.model.session.Session;
-import com.orbitz.consul.model.session.SessionCreatedResponse;
-import com.orbitz.consul.model.session.SessionInfo;
-import org.junit.Before;
-import org.junit.Test;
-
-import java.util.List;
-import java.util.UUID;
-
+import static com.orbitz.consul.TestUtils.randomUUIDString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+
+import com.orbitz.consul.model.session.ImmutableSession;
+import com.orbitz.consul.model.session.Session;
+import com.orbitz.consul.model.session.SessionCreatedResponse;
+import com.orbitz.consul.model.session.SessionInfo;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
 
 public class SessionClientITest extends BaseIntegrationTest {
 
@@ -28,7 +29,7 @@ public class SessionClientITest extends BaseIntegrationTest {
 
     @Test
     public void testCreateAndDestroySession() throws Exception {
-        final Session value = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
+        final Session value = ImmutableSession.builder().name("session_" + randomUUIDString()).build();
         SessionCreatedResponse session = sessionClient.createSession(value);
         assertNotNull(session);
 
@@ -54,7 +55,7 @@ public class SessionClientITest extends BaseIntegrationTest {
 
     @Test
     public void testRenewSession() throws Exception {
-        final Session value = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
+        final Session value = ImmutableSession.builder().name("session_" + randomUUIDString()).build();
 
         SessionCreatedResponse session = sessionClient.createSession(value);
         assertNotNull(session);
@@ -69,9 +70,9 @@ public class SessionClientITest extends BaseIntegrationTest {
 
     @Test
     public void testAcquireLock() {
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
 
-        Session value = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
+        Session value = ImmutableSession.builder().name("session_" + randomUUIDString()).build();
         String sessionId = sessionClient.createSession(value).getId();
         String valueName = value.getName().get();
 
@@ -88,9 +89,9 @@ public class SessionClientITest extends BaseIntegrationTest {
 
     @Test
     public void testAcquireLockTwiceFromSameSession() {
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
 
-        Session value = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
+        Session value = ImmutableSession.builder().name("session_" + randomUUIDString()).build();
         String sessionId = sessionClient.createSession(value).getId();
         String valueName = value.getName().get();
 
@@ -109,13 +110,13 @@ public class SessionClientITest extends BaseIntegrationTest {
 
     @Test
     public void testAcquireLockTwiceFromDifferentSessions() {
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
 
-        Session firstSessionValue = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
+        Session firstSessionValue = ImmutableSession.builder().name("session_" + randomUUIDString()).build();
         String firstSessionId = sessionClient.createSession(firstSessionValue).getId();
         String firstSessionValueContent = firstSessionValue.getName().get();
 
-        Session secondSessionValue = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
+        Session secondSessionValue = ImmutableSession.builder().name("session_" + randomUUIDString()).build();
         String secondSessionId = sessionClient.createSession(secondSessionValue).getId();
         String secondSessionValueNameContent = secondSessionValue.getName().get();
 
@@ -136,9 +137,9 @@ public class SessionClientITest extends BaseIntegrationTest {
 
     @Test
     public void testGetSessionInfo() throws Exception {
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
 
-        Session value = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
+        Session value = ImmutableSession.builder().name("session_" + randomUUIDString()).build();
         String sessionId = sessionClient.createSession(value).getId();
         String valueName = value.getName().get();
 
@@ -158,9 +159,9 @@ public class SessionClientITest extends BaseIntegrationTest {
 
     @Test
     public void testListSessions() throws Exception {
-        String key = UUID.randomUUID().toString();
+        String key = randomUUIDString();
 
-        Session value = ImmutableSession.builder().name("session_" + UUID.randomUUID().toString()).build();
+        Session value = ImmutableSession.builder().name("session_" + randomUUIDString()).build();
         String sessionId = sessionClient.createSession(value).getId();
 
         try {

--- a/src/itest/java/com/orbitz/consul/SnapshotClientITest.java
+++ b/src/itest/java/com/orbitz/consul/SnapshotClientITest.java
@@ -1,5 +1,12 @@
 package com.orbitz.consul;
 
+import static com.orbitz.consul.TestUtils.randomUUIDString;
+import static com.orbitz.consul.Awaiting.awaitWith25MsPoll;
+import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
 import com.orbitz.consul.async.Callback;
 import com.orbitz.consul.option.QueryOptions;
 
@@ -14,16 +21,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import static com.orbitz.consul.Awaiting.awaitWith25MsPoll;
-import static org.awaitility.Awaitility.await;
-import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class SnapshotClientITest extends BaseIntegrationTest {
 
@@ -48,8 +48,8 @@ public class SnapshotClientITest extends BaseIntegrationTest {
 
     @Test
     public void shouldBeAbleToSaveAndRestoreSnapshot() throws MalformedURLException, InterruptedException {
-        String serviceName = UUID.randomUUID().toString();
-        String serviceId = UUID.randomUUID().toString();
+        String serviceName = randomUUIDString();
+        String serviceId = randomUUIDString();
 
         client.agentClient().register(8080, new URL("http://localhost:123/health"), 1000L, serviceName, serviceId,
                 List.of(), Map.of());

--- a/src/itest/java/com/orbitz/consul/cache/HealthCheckCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/HealthCheckCacheITest.java
@@ -1,5 +1,11 @@
 package com.orbitz.consul.cache;
 
+import static com.orbitz.consul.Awaiting.awaitWith25MsPoll;
+import static com.orbitz.consul.TestUtils.randomUUIDString;
+import static java.util.Objects.isNull;
+import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
+import static org.junit.Assert.assertEquals;
+
 import com.orbitz.consul.AgentClient;
 import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.HealthClient;
@@ -9,13 +15,7 @@ import com.orbitz.consul.model.health.HealthCheck;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import static com.orbitz.consul.Awaiting.awaitWith25MsPoll;
-import static java.util.Objects.isNull;
-import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
-import static org.junit.Assert.assertEquals;
 
 public class HealthCheckCacheITest extends BaseIntegrationTest {
 
@@ -29,8 +29,8 @@ public class HealthCheckCacheITest extends BaseIntegrationTest {
     @Test
     public void cacheShouldContainPassingTestsOnly() throws Exception {
         HealthClient healthClient = client.healthClient();
-        String checkName = UUID.randomUUID().toString();
-        String checkId = UUID.randomUUID().toString();
+        String checkName = randomUUIDString();
+        String checkId = randomUUIDString();
 
         agentClient.registerCheck(checkId, checkName, 20L);
         try {

--- a/src/itest/java/com/orbitz/consul/cache/KVCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/KVCacheITest.java
@@ -1,17 +1,24 @@
 package com.orbitz.consul.cache;
 
+import static com.orbitz.consul.Awaiting.awaitAtMost100ms;
+import static com.orbitz.consul.TestUtils.randomUUIDString;
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.Consul;
 import com.orbitz.consul.KeyValueClient;
+import com.orbitz.consul.Synchroniser;
 import com.orbitz.consul.config.CacheConfig;
 import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.kv.Value;
-import com.orbitz.consul.Synchroniser;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
-import junitparams.naming.TestCaseName;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -22,20 +29,14 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static com.orbitz.consul.Awaiting.awaitAtMost100ms;
-import static org.hamcrest.CoreMatchers.anyOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
 
 @RunWith(JUnitParamsRunner.class)
 public class KVCacheITest extends BaseIntegrationTest {
@@ -58,7 +59,7 @@ public class KVCacheITest extends BaseIntegrationTest {
 
     @Test
     public void nodeCacheKvTest() throws Exception {
-        var root = UUID.randomUUID().toString();
+        var root = randomUUIDString();
 
         for (int i = 0; i < 5; i++) {
             kvClient.putValue(root + "/" + i, String.valueOf(i));
@@ -99,7 +100,7 @@ public class KVCacheITest extends BaseIntegrationTest {
 
     @Test
     public void testListeners() throws Exception {
-        var root = UUID.randomUUID().toString();
+        var root = randomUUIDString();
         final List<Map<String, Value>> events = new ArrayList<>();
 
         try (var cache = KVCache.newCache(kvClient, root, 10)) {
@@ -138,7 +139,7 @@ public class KVCacheITest extends BaseIntegrationTest {
 
     @Test
     public void testLateListenersGetValues() throws Exception {
-        var root = UUID.randomUUID().toString();
+        var root = randomUUIDString();
 
         try (var cache = KVCache.newCache(kvClient, root, 10)) {
             cache.start();
@@ -171,7 +172,7 @@ public class KVCacheITest extends BaseIntegrationTest {
 
     @Test
     public void testListenersNonExistingKeys() throws Exception {
-        var root = UUID.randomUUID().toString();
+        var root = randomUUIDString();
 
         try (var cache = KVCache.newCache(kvClient, root, 10)) {
             final List<Map<String, Value>> events = new ArrayList<>();
@@ -192,7 +193,7 @@ public class KVCacheITest extends BaseIntegrationTest {
 
     @Test
     public void testLifeCycleDoubleStart() throws Exception {
-        var root = UUID.randomUUID().toString();
+        var root = randomUUIDString();
 
         try (var cache = KVCache.newCache(kvClient, root, 10)) {
             assertEquals(ConsulCache.State.LATENT, cache.getState());
@@ -210,7 +211,7 @@ public class KVCacheITest extends BaseIntegrationTest {
 
     @Test
     public void testLifeCycle() throws Exception {
-        var root = UUID.randomUUID().toString();
+        var root = randomUUIDString();
         final List<Map<String, Value>> events = new ArrayList<>();
 
         // intentionally not using try-with-resources to test the cache lifecycle methods
@@ -255,8 +256,8 @@ public class KVCacheITest extends BaseIntegrationTest {
 
     @Test
     public void ensureCacheInitialization() throws InterruptedException {
-        var key = UUID.randomUUID().toString();
-        var value = UUID.randomUUID().toString();
+        var key = randomUUIDString();
+        var value = randomUUIDString();
         kvClient.putValue(key, value);
 
         final CountDownLatch completed = new CountDownLatch(1);
@@ -287,9 +288,9 @@ public class KVCacheITest extends BaseIntegrationTest {
                 new ThreadFactoryBuilder().setDaemon(true).setNameFormat("kvcache-itest-%d").build()
         );
 
-        var key = UUID.randomUUID().toString();
-        var value = UUID.randomUUID().toString();
-        var newValue = UUID.randomUUID().toString();
+        var key = randomUUIDString();
+        var value = randomUUIDString();
+        var newValue = randomUUIDString();
         kvClient.putValue(key, value);
 
         final CountDownLatch completed = new CountDownLatch(2);

--- a/src/itest/java/com/orbitz/consul/cache/ServiceCatalogCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/ServiceCatalogCacheITest.java
@@ -1,5 +1,6 @@
 package com.orbitz.consul.cache;
 
+import static com.orbitz.consul.TestUtils.randomUUIDString;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.TWO_SECONDS;
 import static org.junit.Assert.assertEquals;
@@ -13,7 +14,6 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 
@@ -24,7 +24,7 @@ public class ServiceCatalogCacheITest extends BaseIntegrationTest {
 
     @Test
     public void testWatchService() throws InterruptedException {
-        String name = UUID.randomUUID().toString();
+        String name = randomUUIDString();
         String serviceId1 = createAutoDeregisterServiceId();
         String serviceId2 = createAutoDeregisterServiceId();
 

--- a/src/itest/java/com/orbitz/consul/cache/ServiceHealthCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/ServiceHealthCacheITest.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul.cache;
 
 import static com.orbitz.consul.Awaiting.awaitWith25MsPoll;
+import static com.orbitz.consul.TestUtils.randomUUIDString;
 import static java.util.Objects.isNull;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
@@ -21,7 +22,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -40,8 +40,8 @@ public class ServiceHealthCacheITest extends BaseIntegrationTest {
     @Test
     public void nodeCacheServicePassingTest() throws Exception {
         var healthClient = client.healthClient();
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
 
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         agentClient.pass(serviceId);
@@ -77,9 +77,9 @@ public class ServiceHealthCacheITest extends BaseIntegrationTest {
     @Test
     public void testServicesAreUniqueByID() throws Exception {
         var healthClient = client.healthClient();
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
-        var serviceId2 = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var serviceId2 = randomUUIDString();
 
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         agentClient.pass(serviceId);
@@ -116,8 +116,8 @@ public class ServiceHealthCacheITest extends BaseIntegrationTest {
 
     @Test
     public void shouldNotifyListener() throws Exception {
-        var serviceName = UUID.randomUUID().toString();
-        var serviceId = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
 
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         agentClient.pass(serviceId);
@@ -151,7 +151,7 @@ public class ServiceHealthCacheITest extends BaseIntegrationTest {
 
     @Test
     public void shouldNotifyLateListenersIfNoService() throws Exception {
-        var serviceName = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
 
         try (ServiceHealthCache cache = ServiceHealthCache.newCache(client.healthClient(), serviceName)) {
             final List<Map<ServiceHealthKey, ServiceHealth>> events = new ArrayList<>();
@@ -168,7 +168,7 @@ public class ServiceHealthCacheITest extends BaseIntegrationTest {
 
     @Test
     public void shouldNotifyLateListenersRaceCondition() throws Exception {
-        var serviceName = UUID.randomUUID().toString();
+        var serviceName = randomUUIDString();
 
         try (var cache = ServiceHealthCache.newCache(client.healthClient(), serviceName)) {
             final var eventCount = new AtomicInteger(0);

--- a/src/test/java/com/orbitz/consul/TestUtils.java
+++ b/src/test/java/com/orbitz/consul/TestUtils.java
@@ -1,0 +1,14 @@
+package com.orbitz.consul;
+
+import java.util.UUID;
+
+public class TestUtils {
+
+    private TestUtils() {
+        // utility class
+    }
+
+    public static String randomUUIDString() {
+        return UUID.randomUUID().toString();
+    }
+}


### PR DESCRIPTION
* Add TestUtils in src/test
* Add randomUUIDString to TestUtils
* Replace all 200+ usages of UUID.randomUUID().toString()
* Re-organize imports in the affected tests