### PR TITLE
Fix flaky test: ServiceCatalogCacheITest#testWatchService

### DIFF
--- a/src/itest/java/com/orbitz/consul/cache/ServiceCatalogCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/ServiceCatalogCacheITest.java
@@ -1,9 +1,8 @@
 package com.orbitz.consul.cache;
 
+import static com.orbitz.consul.Awaiting.awaitAtMost500ms;
 import static com.orbitz.consul.TestUtils.randomUUIDString;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
-import static org.awaitility.Durations.FIVE_SECONDS;
 
 import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.model.catalog.CatalogService;
@@ -21,22 +20,25 @@ class ServiceCatalogCacheITest extends BaseIntegrationTest {
 
     @Test
     void testWatchService() throws InterruptedException {
-        String name = randomUUIDString();
-        String serviceId1 = createAutoDeregisterServiceId();
-        String serviceId2 = createAutoDeregisterServiceId();
+        var serviceName = randomUUIDString();
+        var serviceId1 = createAutoDeregisterServiceId();
+        var serviceId2 = createAutoDeregisterServiceId();
 
         List<Map<String, CatalogService>> result = new CopyOnWriteArrayList<>();
 
-        ServiceCatalogCache cache = ServiceCatalogCache.newCache(client.catalogClient(), name);
-        cache.addListener(result::add);
+        try (var cache = ServiceCatalogCache.newCache(client.catalogClient(), serviceName)) {
+            cache.addListener(result::add);
 
-        cache.start();
-        cache.awaitInitialized(3, TimeUnit.SECONDS);
+            cache.start();
+            cache.awaitInitialized(3, TimeUnit.SECONDS);
+            client.agentClient().register(20001, 20, serviceName, serviceId1, NO_TAGS, NO_META);
+            awaitAtMost500ms().until(() -> serviceIsRegistered(serviceName, serviceId1));
 
-        client.agentClient().register(20001, 20, name, serviceId1, NO_TAGS, NO_META);
-        client.agentClient().register(20002, 20, name, serviceId2, NO_TAGS, NO_META);
+            client.agentClient().register(20002, 20, serviceName, serviceId2, NO_TAGS, NO_META);
+            awaitAtMost500ms().until(() -> serviceIsRegistered(serviceName, serviceId1));
+        }
 
-        await().atMost(FIVE_SECONDS).until(() -> result.size() == 3);
+        assertThat(result).hasSize(3);
 
         assertThat(result.get(0)).isEmpty();
         assertThat(result.get(1)).hasSize(1);
@@ -50,5 +52,12 @@ class ServiceCatalogCacheITest extends BaseIntegrationTest {
 
         assertThat(result.get(1).get(serviceId1).getServiceId()).isEqualTo(serviceId1);
         assertThat(result.get(2).get(serviceId2).getServiceId()).isEqualTo(serviceId2);
+    }
+
+    private boolean serviceIsRegistered(String serviceName, String serviceId) {
+        return client.catalogClient().getService(serviceName)
+                .getResponse()
+                .stream()
+                .anyMatch(catalogService -> catalogService.getServiceId().equals(serviceId));
     }
 }


### PR DESCRIPTION
Wait between service registrations to ensure we get notified with a different map for each of them. For more details, see my comment here:

https://github.com/kiwiproject/consul-client/issues/123#issuecomment-1564620221

Also, wrap the cache with a try-with-resources to ensure a graceful shutdown.

Fixes #123