### PR TITLE
Sonar: reduce Cognitive Complexity of ConsulCache constructor

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -151,9 +151,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
                 // metadata changes
                 lastContact.set(consulResponse.getLastContact());
                 isKnownLeader.set(consulResponse.isKnownLeader());
-            }
 
-            if (changed) {
                 boolean locked = false;
                 if (state.get() == State.STARTING) {
                     listenersStartingLock.lock();

--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -15,7 +15,6 @@ import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.monitoring.ClientEventHandler;
 import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.QueryOptions;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,11 +117,9 @@ public class ConsulCache<K, V> implements AutoCloseable {
      * @implNote This was extracted from an anonymous class declaration into a separate class mainly
      * for organization and (somewhat) better readability. Several small methods were also extracted
      * such as notifyListeners, and the updateIndex method was moved into this class since it is
-     * only used here.
-     *
-     * It cannot be static because it uses instance fields from ConsulCache directly. It might be
-     * possible to make it static if we pass in the required fields to the constructor, since they
-     * are accessed only via their methods and are not reassigned.
+     * only used here. It cannot be static because it uses instance fields from ConsulCache directly.
+     * It might be possible to make it static if we pass in the required fields to the constructor, since
+     * they are accessed only via their methods and are not reassigned.
      */
     class DefaultConsulResponseCallback implements ConsulResponseCallback<List<V>> {
 


### PR DESCRIPTION
* Exctract a new inner class DefaultConsulResponseCallback
* Extract a few private helper methods to make code a bit more readable

Closes #132