### PR TITLE
Maybe fix flaky test: KeyValueITest#testGetValueNotFoundAsync

### DIFF
--- a/src/itest/java/com/orbitz/consul/KeyValueITest.java
+++ b/src/itest/java/com/orbitz/consul/KeyValueITest.java
@@ -426,8 +426,8 @@ class KeyValueITest extends BaseIntegrationTest {
                 assertThat(consulResponse).isNotNull();
                 // No cache, no Cache info
                 assertThat(consulResponse.getCacheReponseInfo()).isEmpty();
-                completed.countDown();
                 success.incrementAndGet();
+                completed.countDown();
             }
 
             @Override
@@ -454,8 +454,8 @@ class KeyValueITest extends BaseIntegrationTest {
             @Override
             public void onComplete(ConsulResponse<Optional<Value>> consulResponse) {
                 assertThat(consulResponse).isNotNull();
-                completed.countDown();
                 success.incrementAndGet();
+                completed.countDown();
             }
 
             @Override


### PR DESCRIPTION
Maybe there is another timing issue here. If so, then by moving the incrementAndGet calls before the calls to countDown on the CountDownLatch, then this might fix the flakiness of this test and make it pass consistently in GitHub actions.

Closes #141