### PR TITLE
Rename all LOGGER to LOG

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/ConsulCache.java
+++ b/src/main/java/com/orbitz/consul/cache/ConsulCache.java
@@ -48,7 +48,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
         LATENT, STARTING, STARTED, STOPPED
     }
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ConsulCache.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConsulCache.class);
 
     private final AtomicReference<BigInteger> latestIndex = new AtomicReference<>(null);
     private final AtomicLong lastContact = new AtomicLong();
@@ -137,7 +137,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
 
             long elapsedTime = stopWatch.elapsed(TimeUnit.MILLISECONDS);
             updateIndex(consulResponse);
-            LOGGER.debug("Consul cache updated for {} (index={}), request duration: {} ms",
+            LOG.debug("Consul cache updated for {} (index={}), request duration: {} ms",
                     cacheDescriptor, latestIndex, elapsedTime);
 
             ImmutableMap<K, V> full = convertToMap(consulResponse);
@@ -192,7 +192,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
                 try {
                     l.notify(newValues);
                 } catch (RuntimeException e) {
-                    LOGGER.warn("ConsulCache Listener's notify method threw an exception.", e);
+                    LOG.warn("ConsulCache Listener's notify method threw an exception.", e);
                 }
             }
         }
@@ -216,7 +216,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
             String message = String.format("Error getting response from consul for %s, will retry in %d %s",
                     cacheDescriptor, delayMs, TimeUnit.MILLISECONDS);
 
-            cacheConfig.getRefreshErrorLoggingConsumer().accept(LOGGER, message, throwable);
+            cacheConfig.getRefreshErrorLoggingConsumer().accept(LOG, message, throwable);
 
             scheduler.schedule(ConsulCache.this::runCallback, delayMs, TimeUnit.MILLISECONDS);
         }
@@ -237,7 +237,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
         try {
             eventHandler.cacheStop(cacheDescriptor);
         } catch (RejectedExecutionException ree) {
-            LOGGER.error("Unable to propagate cache stop event. ", ree);
+            LOG.error("Unable to propagate cache stop event. ", ree);
         }
 
         State previous = state.getAndSet(State.STOPPED);
@@ -290,7 +290,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
                 if (!keySet.contains(key)) {
                     builder.put(key, v);
                 } else {
-                    LOGGER.warn("Duplicate service encountered. May differ by tags. Try using more specific tags? {}", key);
+                    LOG.warn("Duplicate service encountered. May differ by tags. Try using more specific tags? {}", key);
                 }
             }
             keySet.add(key);
@@ -363,7 +363,7 @@ public class ConsulCache<K, V> implements AutoCloseable {
                 try {
                     listener.notify(lastResponse.get());
                 } catch (RuntimeException e) {
-                    LOGGER.warn("ConsulCache Listener's notify method threw an exception.", e);
+                    LOG.warn("ConsulCache Listener's notify method threw an exception.", e);
                 }
             }
         }

--- a/src/main/java/com/orbitz/consul/cache/TimeoutInterceptor.java
+++ b/src/main/java/com/orbitz/consul/cache/TimeoutInterceptor.java
@@ -1,10 +1,13 @@
 package com.orbitz.consul.cache;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.orbitz.consul.config.CacheConfig;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 public class TimeoutInterceptor implements Interceptor {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(TimeoutInterceptor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TimeoutInterceptor.class);
 
     private CacheConfig config;
 
@@ -53,7 +56,9 @@ public class TimeoutInterceptor implements Interceptor {
                 .proceed(request);
     }
 
-    private Duration parseWaitQuery(String query) {
+    @VisibleForTesting
+    @Nullable
+    static Duration parseWaitQuery(String query) {
         if (Strings.isNullOrEmpty(query)) {
             return null;
         }
@@ -61,12 +66,12 @@ public class TimeoutInterceptor implements Interceptor {
         Duration wait = null;
         try {
             if (query.contains("m")) {
-                wait = Duration.ofMinutes(Integer.valueOf(query.replace("m","")));
+                wait = Duration.ofMinutes(Long.parseLong(query.replace("m","")));
             } else if (query.contains("s")) {
-                wait = Duration.ofSeconds(Integer.valueOf(query.replace("s","")));
+                wait = Duration.ofSeconds(Long.parseLong(query.replace("s","")));
             }
         } catch (Exception e) {
-            LOGGER.warn(String.format("Error while extracting wait duration from query parameters: %s", query));
+            LOG.warn(String.format("Error while extracting wait duration from query parameters: %s", query));
         }
         return wait;
     }

--- a/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
+++ b/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
@@ -17,7 +17,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ConsulFailoverInterceptor implements Interceptor {
-	private static final Logger LOGGER = LoggerFactory.getLogger(ConsulFailoverInterceptor.class);
+
+	private static final Logger LOG = LoggerFactory.getLogger(ConsulFailoverInterceptor.class);
 
 	// The consul failover strategy
 	private ConsulFailoverStrategy strategy;
@@ -67,7 +68,7 @@ public class ConsulFailoverInterceptor implements Interceptor {
 					// This is because a 400 series error is a valid code (Permission Denied/Key Not Found)
 					return chain.proceed(next);
 				} catch (Exception ex) {
-					LOGGER.debug("Failed to connect to {}", nextRequest.get().url(), ex);
+					LOG.debug("Failed to connect to {}", nextRequest.get().url(), ex);
 					strategy.markRequestFailed(nextRequest.get());
 				}
 			}


### PR DESCRIPTION
* This makes the loggers consistent across classes
* Add test of TimeoutInterceptor#parseWaitQuery
* Change TimeoutInterceptor#parseWaitQuery to be static and annotate with VisibleForTesting and Nullable annotations

Part of #14