### PR TITLE
Use 'var' in unit tests where type is clear

### DIFF
--- a/src/itest/java/com/orbitz/consul/StatusClientITest.java
+++ b/src/itest/java/com/orbitz/consul/StatusClientITest.java
@@ -9,7 +9,6 @@ import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
@@ -28,7 +27,7 @@ class StatusClientITest extends BaseIntegrationTest {
     static void getIps() throws RuntimeException {
         try {
             InetAddress[] externalIps = InetAddress.getAllByName(InetAddress.getLocalHost().getCanonicalHostName());
-            ips.addAll(Arrays.asList(externalIps));
+            ips.addAll(List.of(externalIps));
         } catch (UnknownHostException ex) {
            LOG.warn("Could not determine fully qualified host name. Continuing.", ex);
         }

--- a/src/test/java/com/orbitz/consul/KeyValueClientFactory.java
+++ b/src/test/java/com/orbitz/consul/KeyValueClientFactory.java
@@ -10,7 +10,9 @@ public class KeyValueClientFactory {
     private KeyValueClientFactory() {
     }
 
-    public static KeyValueClient create(KeyValueClient.Api api, ClientConfig config, ClientEventCallback eventCallback,
+    public static KeyValueClient create(KeyValueClient.Api api,
+                                        ClientConfig config,
+                                        ClientEventCallback eventCallback,
                                         Consul.NetworkTimeoutConfig networkTimeoutConfig) {
         return new KeyValueClient(api, config, eventCallback, networkTimeoutConfig);
     }

--- a/src/test/java/com/orbitz/consul/MockApiService.java
+++ b/src/test/java/com/orbitz/consul/MockApiService.java
@@ -22,8 +22,8 @@ public class MockApiService implements KeyValueClient.Api {
 
     @Override
     public Call<List<Value>> getValue(String key, Map<String, Object> query) {
-        final Headers headers = Headers.of("X-Consul-Knownleader", "true");
-        final Call<List<Object>> call = Calls.response(Response.success(List.of(), headers));
+        var headers = Headers.of("X-Consul-Knownleader", "true");
+        Call<List<Object>> call = Calls.response(Response.success(List.of(), headers));
         return delegate.returning(call).getValue(key, query);
     }
 

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -19,7 +19,6 @@ import com.orbitz.consul.monitoring.ClientEventHandler;
 import com.orbitz.consul.option.ConsistencyMode;
 import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.QueryOptions;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,7 +28,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.math.BigInteger;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -99,16 +97,16 @@ class ConsulCacheTest {
      */
     @Test
     void testDuplicateServicesDontCauseFailure() {
-        final Function<Value, String> keyExtractor = input -> "SAME_KEY";
-        final List<Value> response = Arrays.asList(mock(Value.class), mock(Value.class));
-        CacheConfig cacheConfig = mock(CacheConfig.class);
-        ClientEventHandler eventHandler = mock(ClientEventHandler.class);
+        Function<Value, String> keyExtractor = input -> "SAME_KEY";
+        List<Value> response = List.of(mock(Value.class), mock(Value.class));
 
-        final StubCallbackConsumer callbackConsumer = new StubCallbackConsumer(List.of());
+        var cacheConfig = mock(CacheConfig.class);
+        var eventHandler = mock(ClientEventHandler.class);
+        var callbackConsumer = new StubCallbackConsumer(List.of());
 
         try (var consulCache = new ConsulCache<>(keyExtractor, callbackConsumer, cacheConfig, eventHandler, new CacheDescriptor(""))) {
-            final ConsulResponse<List<Value>> consulResponse = new ConsulResponse<>(response, 0, false, BigInteger.ONE, null, null);
-            final ImmutableMap<String, Value> map = consulCache.convertToMap(consulResponse);
+            ConsulResponse<List<Value>> consulResponse = new ConsulResponse<>(response, 0, false, BigInteger.ONE, null, null);
+            ImmutableMap<String, Value> map = consulCache.convertToMap(consulResponse);
             assertThat(map).isNotNull();
             // Second copy has been weeded out
             assertThat(map).hasSize(1);
@@ -117,26 +115,26 @@ class ConsulCacheTest {
 
     @Test
     void testWatchParamsWithNoAdditionalOptions() {
-        BigInteger index = new BigInteger("12");
-        QueryOptions expectedOptions = ImmutableQueryOptions.builder()
+        var index = new BigInteger("12");
+        var expectedQueryOptions = ImmutableQueryOptions.builder()
                 .index(index)
                 .wait("10s")
                 .build();
-        QueryOptions actualOptions = ConsulCache.watchParams(index, 10, QueryOptions.BLANK);
-        assertThat(actualOptions).isEqualTo(expectedOptions);
+        var actualQueryOptions = ConsulCache.watchParams(index, 10, QueryOptions.BLANK);
+        assertThat(actualQueryOptions).isEqualTo(expectedQueryOptions);
     }
 
     @Test
     void testWatchParamsWithAdditionalOptions() {
-        BigInteger index = new BigInteger("12");
-        QueryOptions additionalOptions = ImmutableQueryOptions.builder()
+        var index = new BigInteger("12");
+        var additionalQueryOptions = ImmutableQueryOptions.builder()
                 .consistencyMode(ConsistencyMode.STALE)
                 .addTag("someTag")
                 .token("186596")
                 .near("156892")
                 .build();
 
-        QueryOptions expectedOptions = ImmutableQueryOptions.builder()
+        var expectedQueryOptions = ImmutableQueryOptions.builder()
                 .index(index)
                 .wait("10s")
                 .consistencyMode(ConsistencyMode.STALE)
@@ -145,29 +143,29 @@ class ConsulCacheTest {
                 .near("156892")
                 .build();
 
-        QueryOptions actualOptions = ConsulCache.watchParams(index, 10, additionalOptions);
-        assertThat(actualOptions).isEqualTo(expectedOptions);
+        var actualQueryOptions = ConsulCache.watchParams(index, 10, additionalQueryOptions);
+        assertThat(actualQueryOptions).isEqualTo(expectedQueryOptions);
     }
 
     @Test
     void testWatchParamsWithAdditionalIndexAndWaitingThrows() {
-        BigInteger index = new BigInteger("12");
-        QueryOptions additionalOptions = ImmutableQueryOptions.builder()
+        var index = new BigInteger("12");
+        var additionalQueryOptions = ImmutableQueryOptions.builder()
                 .index(index)
                 .wait("10s")
                 .build();
 
         assertThatIllegalArgumentException()
-                .isThrownBy(() -> ConsulCache.watchParams(index, 10, additionalOptions));
+                .isThrownBy(() -> ConsulCache.watchParams(index, 10, additionalQueryOptions));
     }
 
     @ParameterizedTest(name = "min Delay: {0}, max Delay: {1}")
     @MethodSource("getRetryDurationSamples")
     void testRetryDuration(Duration minDelay, Duration maxDelay) {
-        CacheConfig cacheConfig = CacheConfig.builder().withBackOffDelay(minDelay, maxDelay).build();
+        var cacheConfig = CacheConfig.builder().withBackOffDelay(minDelay, maxDelay).build();
         for (int i=0; i < 1000; i++) {
             long retryDurationMs = ConsulCache.computeBackOffDelayMs(cacheConfig);
-            Assertions.assertThat(retryDurationMs)
+            assertThat(retryDurationMs)
                     .describedAs("Retry duration expected between %s and %s but got %d ms", minDelay, maxDelay, retryDurationMs)
                     .isBetween(minDelay.toMillis(), maxDelay.toMillis());
         }
@@ -186,25 +184,25 @@ class ConsulCacheTest {
 
     @Test
     void testListenerIsCalled() {
-        final Function<Value, String> keyExtractor = Value::getKey;
+        Function<Value, String> keyExtractor = Value::getKey;
 
-        final CacheConfig cacheConfig = CacheConfig.builder().build();
-        ClientEventHandler eventHandler = mock(ClientEventHandler.class);
+        var cacheConfig = CacheConfig.builder().build();
+        var eventHandler = mock(ClientEventHandler.class);
 
-        final String key = "foo";
-        final ImmutableValue value = ImmutableValue.builder()
+        var key = "foo";
+        var value = ImmutableValue.builder()
                 .createIndex(1)
                 .modifyIndex(2)
                 .lockIndex(2)
                 .key(key)
                 .flags(0)
                 .build();
-        final List<Value> result = List.of(value);
-        final StubCallbackConsumer callbackConsumer = new StubCallbackConsumer(result);
+        List<Value> result = List.of(value);
+        var callbackConsumer = new StubCallbackConsumer(result);
 
         try (var cache = new ConsulCache<>(keyExtractor, callbackConsumer, cacheConfig, eventHandler, new CacheDescriptor(""))) {
 
-            final StubListener listener = new StubListener();
+            var listener = new StubListener();
 
             cache.addListener(listener);
             cache.start();
@@ -232,27 +230,28 @@ class ConsulCacheTest {
 
     @Test
     void testListenerThrowingExceptionIsIsolated() {
-        final Function<Value, String> keyExtractor = Value::getKey;
-        final CacheConfig cacheConfig = CacheConfig.builder()
+        Function<Value, String> keyExtractor = Value::getKey;
+        var cacheConfig = CacheConfig.builder()
                 .withMinDelayBetweenRequests(Duration.ofSeconds(10))
                 .build();
-        ClientEventHandler eventHandler = mock(ClientEventHandler.class);
+        var eventHandler = mock(ClientEventHandler.class);
 
-        final String key = "foo";
-        final ImmutableValue value = ImmutableValue.builder()
+        var key = "foo";
+        var value = ImmutableValue.builder()
                 .createIndex(1)
                 .modifyIndex(2)
                 .lockIndex(2)
                 .key(key)
                 .flags(0)
                 .build();
-        final List<Value> result = List.of(value);
-        try (final AsyncCallbackConsumer callbackConsumer = new AsyncCallbackConsumer(result)) {
-            try (final ConsulCache<String, Value> cache = new ConsulCache<>(keyExtractor, callbackConsumer, cacheConfig,
-                        eventHandler, new CacheDescriptor(""))) {
+        List<Value> result = List.of(value);
 
-                final StubListener goodListener = new StubListener();
-                final AlwaysThrowsListener badListener1 = new AlwaysThrowsListener();
+        try (var callbackConsumer = new AsyncCallbackConsumer(result)) {
+            try (var cache = new ConsulCache<String, Value>(
+                    keyExtractor, callbackConsumer, cacheConfig, eventHandler, new CacheDescriptor(""))) {
+
+                var goodListener = new StubListener();
+                var badListener1 = new AlwaysThrowsListener();
 
                 cache.addListener(badListener1);
                 cache.addListener(goodListener);
@@ -263,7 +262,7 @@ class ConsulCacheTest {
                 assertThat(goodListener.getCallCount()).isEqualTo(1);
                 assertThat(callbackConsumer.getCallCount()).isEqualTo(1);
 
-                final Map<String, Value> lastValues = goodListener.getLastValues();
+                Map<String, Value> lastValues = goodListener.getLastValues();
                 assertThat(lastValues).isNotNull();
                 assertThat(lastValues).hasSameSizeAs(result);
                 assertThat(lastValues).containsKey(key);
@@ -274,36 +273,35 @@ class ConsulCacheTest {
 
     @Test
     void testExceptionReceivedFromListenerWhenAlreadyStarted() {
-        final Function<Value, String> keyExtractor = Value::getKey;
-        final CacheConfig cacheConfig = CacheConfig.builder()
+        Function<Value, String> keyExtractor = Value::getKey;
+        var cacheConfig = CacheConfig.builder()
                 .withMinDelayBetweenRequests(Duration.ofSeconds(10))
                 .build();
-        final ClientEventHandler eventHandler = mock(ClientEventHandler.class);
+        var eventHandler = mock(ClientEventHandler.class);
 
-        final String key = "foo";
-        final ImmutableValue value = ImmutableValue.builder()
+        var key = "foo";
+        var value = ImmutableValue.builder()
                 .createIndex(1)
                 .modifyIndex(2)
                 .lockIndex(2)
                 .key(key)
                 .flags(0)
                 .build();
-        final List<Value> result = List.of(value);
-        final StubCallbackConsumer callbackConsumer = new StubCallbackConsumer(
-                result);
+        List<Value> result = List.of(value);
+        var callbackConsumer = new StubCallbackConsumer(result);
 
-        try (final ConsulCache<String, Value> cache = new ConsulCache<>(keyExtractor, callbackConsumer, cacheConfig,
-                eventHandler, new CacheDescriptor(""))) {
+        try (var cache = new ConsulCache<String, Value>(
+                keyExtractor, callbackConsumer, cacheConfig, eventHandler, new CacheDescriptor(""))) {
 
-            final AlwaysThrowsListener badListener = new AlwaysThrowsListener();
+            var badListener = new AlwaysThrowsListener();
 
             cache.start();
 
             // Adding listener after cache is already started
-            final boolean isAdded = cache.addListener(badListener);
-            assertThat(isAdded).isTrue();
+            var wasAdded = cache.addListener(badListener);
+            assertThat(wasAdded).isTrue();
 
-            final StubListener goodListener = new StubListener();
+            var goodListener = new StubListener();
             cache.addListener(goodListener);
 
             assertThat(goodListener.getCallCount()).isEqualTo(1);

--- a/src/test/java/com/orbitz/consul/cache/TimeoutInterceptorTest.java
+++ b/src/test/java/com/orbitz/consul/cache/TimeoutInterceptorTest.java
@@ -35,7 +35,7 @@ class TimeoutInterceptorTest {
         CacheConfig config = createConfigMock(enabled, margin);
         Interceptor.Chain chain = createChainMock(defaultTimeout, url);
 
-        TimeoutInterceptor interceptor = new TimeoutInterceptor(config);
+        var interceptor = new TimeoutInterceptor(config);
         interceptor.intercept(chain);
         verify(chain).withReadTimeout(expectedTimeoutMs, TimeUnit.MILLISECONDS);
     }
@@ -62,16 +62,16 @@ class TimeoutInterceptorTest {
     }
 
     private CacheConfig createConfigMock(boolean autoAdjustEnabled, int autoAdjustMargin) {
-        CacheConfig config = mock(CacheConfig.class);
+        var config = mock(CacheConfig.class);
         when(config.isTimeoutAutoAdjustmentEnabled()).thenReturn(autoAdjustEnabled);
         when(config.getTimeoutAutoAdjustmentMargin()).thenReturn(Duration.ofMillis(autoAdjustMargin));
         return config;
     }
 
     private Interceptor.Chain createChainMock(int defaultTimeout, String url) throws IOException {
-        Request request = new Request.Builder().url(url).build();
+        var request = new Request.Builder().url(url).build();
 
-        Interceptor.Chain chain = mock(Interceptor.Chain.class);
+        var chain = mock(Interceptor.Chain.class);
         when(chain.request()).thenReturn(request);
         when(chain.readTimeoutMillis()).thenReturn(defaultTimeout);
         when(chain.withReadTimeout(anyInt(), any(TimeUnit.class))).thenReturn(chain);

--- a/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
@@ -36,7 +36,7 @@ class CacheConfigTest {
 
     @Test
     void testDefaults() {
-        CacheConfig config = CacheConfig.builder().build();
+        var config = CacheConfig.builder().build();
         assertThat(config.getMinimumBackOffDelay()).isEqualTo(CacheConfig.DEFAULT_BACKOFF_DELAY);
         assertThat(config.getMaximumBackOffDelay()).isEqualTo(CacheConfig.DEFAULT_BACKOFF_DELAY);
         assertThat(config.getWatchDuration()).isEqualTo(CacheConfig.DEFAULT_WATCH_DURATION);
@@ -45,8 +45,8 @@ class CacheConfigTest {
         assertThat(config.isTimeoutAutoAdjustmentEnabled()).isEqualTo(CacheConfig.DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_ENABLED);
         assertThat(config.getTimeoutAutoAdjustmentMargin()).isEqualTo(CacheConfig.DEFAULT_TIMEOUT_AUTO_ADJUSTMENT_MARGIN);
 
-        AtomicBoolean loggedAsWarn = new AtomicBoolean(false);
-        Logger logger = mock(Logger.class);
+        var loggedAsWarn = new AtomicBoolean(false);
+        var logger = mock(Logger.class);
         doAnswer(vars -> {
             loggedAsWarn.set(true);
             return null;
@@ -65,7 +65,7 @@ class CacheConfigTest {
     @ParameterizedTest(name = "Delay: {0}")
     @MethodSource("getDurationSamples")
     void testOverrideBackOffDelay(Duration backOffDelay) {
-        CacheConfig config = CacheConfig.builder().withBackOffDelay(backOffDelay).build();
+        var config = CacheConfig.builder().withBackOffDelay(backOffDelay).build();
         assertThat(config.getMinimumBackOffDelay()).isEqualTo(backOffDelay);
         assertThat(config.getMaximumBackOffDelay()).isEqualTo(backOffDelay);
     }
@@ -80,41 +80,41 @@ class CacheConfigTest {
     @ParameterizedTest(name = "Delay: {0}")
     @MethodSource("getDurationSamples")
     void testOverrideMinDelayBetweenRequests(Duration delayBetweenRequests) {
-        CacheConfig config = CacheConfig.builder().withMinDelayBetweenRequests(delayBetweenRequests).build();
+        var config = CacheConfig.builder().withMinDelayBetweenRequests(delayBetweenRequests).build();
         assertThat(config.getMinimumDurationBetweenRequests()).isEqualTo(delayBetweenRequests);
     }
 
     @ParameterizedTest(name = "Delay: {0}")
     @MethodSource("getDurationSamples")
     void testOverrideMinDelayOnEmptyResult(Duration delayBetweenRequests) {
-        CacheConfig config = CacheConfig.builder().withMinDelayOnEmptyResult(delayBetweenRequests).build();
+        var config = CacheConfig.builder().withMinDelayOnEmptyResult(delayBetweenRequests).build();
         assertThat(config.getMinimumDurationDelayOnEmptyResult()).isEqualTo(delayBetweenRequests);
     }
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void testOverrideTimeoutAutoAdjustmentEnabled(boolean enabled) {
-        CacheConfig config = CacheConfig.builder().withTimeoutAutoAdjustmentEnabled(enabled).build();
+        var config = CacheConfig.builder().withTimeoutAutoAdjustmentEnabled(enabled).build();
         assertThat(config.isTimeoutAutoAdjustmentEnabled()).isEqualTo(enabled);
     }
 
     @ParameterizedTest(name = "Margin: {0}")
     @MethodSource("getDurationSamples")
     void testOverrideTimeoutAutoAdjustmentMargin(Duration margin) {
-        CacheConfig config = CacheConfig.builder().withTimeoutAutoAdjustmentMargin(margin).build();
+        var config = CacheConfig.builder().withTimeoutAutoAdjustmentMargin(margin).build();
         assertThat(config.getTimeoutAutoAdjustmentMargin()).isEqualTo(margin);
     }
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
     void testOverrideRefreshErrorLogConsumer(boolean logLevelWarning) {
-        CacheConfig config = logLevelWarning
+        var config = logLevelWarning
                 ? CacheConfig.builder().withRefreshErrorLoggedAsWarning().build()
                 : CacheConfig.builder().withRefreshErrorLoggedAsError().build();
 
-        AtomicBoolean logged = new AtomicBoolean(false);
-        AtomicBoolean loggedAsWarn = new AtomicBoolean(false);
-        Logger logger = mock(Logger.class);
+        var logged = new AtomicBoolean(false);
+        var loggedAsWarn = new AtomicBoolean(false);
+        var logger = mock(Logger.class);
         doAnswer(vars -> {
             loggedAsWarn.set(true);
             logged.set(true);
@@ -133,14 +133,14 @@ class CacheConfigTest {
 
     @Test
     void testOverrideRefreshErrorLogCustom() {
-        AtomicBoolean loggedAsDebug = new AtomicBoolean(false);
-        Logger logger = mock(Logger.class);
+        var loggedAsDebug = new AtomicBoolean(false);
+        var logger = mock(Logger.class);
         doAnswer(vars -> {
             loggedAsDebug.set(true);
             return null;
         }).when(logger).debug(anyString(), any(Throwable.class));
 
-        CacheConfig config = CacheConfig.builder().withRefreshErrorLoggedAs(Logger::debug).build();
+        var config = CacheConfig.builder().withRefreshErrorLoggedAs(Logger::debug).build();
         config.getRefreshErrorLoggingConsumer().accept(logger, "some string", new Exception("oop"));
         assertThat(loggedAsDebug.get()).isTrue();
     }
@@ -157,7 +157,7 @@ class CacheConfigTest {
     @MethodSource("getMinMaxDurationSamples")
     void testOverrideRandomBackOffDelay(Duration minDelay, Duration maxDelay, boolean isValid) {
         try {
-            CacheConfig config = CacheConfig.builder().withBackOffDelay(minDelay, maxDelay).build();
+            var config = CacheConfig.builder().withBackOffDelay(minDelay, maxDelay).build();
             if (!isValid) {
                 fail("", String.format("Should not be able to build cache with min retry delay %d ms and max retry delay %d ms",
                         minDelay.toMillis(), maxDelay.toMillis()));
@@ -188,55 +188,68 @@ class CacheConfigTest {
 
     @Test
     void testMinDelayOnEmptyResultWithNoResults() {
-        TestCacheSupplier res = new TestCacheSupplier(0, Duration.ofMillis(100));
+        var responseSupplier = new TestCacheSupplier(0, Duration.ofMillis(100));
 
-        try (TestCache cache = TestCache.createCache(CacheConfig.builder()
+        var cacheConfig = CacheConfig.builder()
                 .withMinDelayOnEmptyResult(Duration.ofMillis(100))
-                .build(), res)) {
+                .build();
+
+        try (var cache = TestCache.createCache(cacheConfig, responseSupplier)) {
             cache.start();
 
-            awaitAtMost500ms().until(() -> res.run > 0);
+            awaitAtMost500ms().until(() -> responseSupplier.run > 0);
         }
     }
 
     @Test
     void testMinDelayOnEmptyResultWithResults() {
-        TestCacheSupplier res = new TestCacheSupplier(1, Duration.ofMillis(50));
+        var responseSupplier = new TestCacheSupplier(1, Duration.ofMillis(50));
 
-        try (TestCache cache = TestCache.createCache(CacheConfig.builder()
+        var cacheConfig = CacheConfig.builder()
                 .withMinDelayOnEmptyResult(Duration.ofMillis(100))
                 .withMinDelayBetweenRequests(Duration.ofMillis(50)) // do not blow ourselves up
-                .build(), res)) {
+                .build();
+
+        try (var cache = TestCache.createCache(cacheConfig, responseSupplier)) {
             cache.start();
-            awaitAtMost500ms().until(() -> res.run > 0);
+            awaitAtMost500ms().until(() -> responseSupplier.run > 0);
         }
     }
 
 
     static class TestCache extends ConsulCache<Integer, Integer> {
-        private TestCache(Function<Integer, Integer> keyConversion, CallbackConsumer<Integer> callbackConsumer, CacheConfig cacheConfig, ClientEventHandler eventHandler, CacheDescriptor cacheDescriptor) {
+
+        private TestCache(Function<Integer, Integer> keyConversion,
+                CallbackConsumer<Integer> callbackConsumer,
+                CacheConfig cacheConfig,
+                ClientEventHandler eventHandler,
+                CacheDescriptor cacheDescriptor) {
+
             super(keyConversion, callbackConsumer, cacheConfig, eventHandler, cacheDescriptor);
         }
 
-        static TestCache createCache(CacheConfig config, Supplier<List<Integer>> res) {
-            ClientEventHandler ev = mock(ClientEventHandler.class);
-            CacheDescriptor cacheDescriptor = new CacheDescriptor("test", "test");
+        static TestCache createCache(CacheConfig config, Supplier<List<Integer>> responseSupplier) {
+            var clientEventHandler = mock(ClientEventHandler.class);
+            var cacheDescriptor = new CacheDescriptor("test", "test");
 
             final CallbackConsumer<Integer> callbackConsumer = (index, callback) ->
-                    callback.onComplete(new ConsulResponse<>(res.get(), 0, true, BigInteger.ZERO, null, null));
+                    callback.onComplete(new ConsulResponse<>(responseSupplier.get(), 0, true, BigInteger.ZERO, null, null));
 
             return new TestCache((i) -> i,
                     callbackConsumer,
                     config,
-                    ev,
+                    clientEventHandler,
                     cacheDescriptor);
         }
     }
 
     static class TestCacheSupplier implements Supplier<List<Integer>> {
-        int run = 0;
-        int resultCount;
+
+        private final int resultCount;
         private final Duration expectedInterval;
+
+        // mutable fields
+        private int run;
         private LocalTime lastCall;
 
         TestCacheSupplier(int resultCount, Duration expectedInterval) {
@@ -247,9 +260,9 @@ class CacheConfigTest {
         @Override
         public List<Integer> get() {
             if (nonNull(lastCall)) {
-                long between = Duration.between(lastCall, LocalTime.now()).toMillis();
-                assertThat(Math.abs(between - expectedInterval.toMillis()))
-                        .describedAs(String.format("expected duration between calls of %d, got %s", expectedInterval.toMillis(), between))
+                long millisBetween = Duration.between(lastCall, LocalTime.now()).toMillis();
+                assertThat(Math.abs(millisBetween - expectedInterval.toMillis()))
+                        .describedAs("expected duration between calls of %d, got %s", expectedInterval.toMillis(), millisBetween)
                         .isLessThan(20);
             }
             lastCall = LocalTime.now();

--- a/src/test/java/com/orbitz/consul/model/agent/CheckTest.java
+++ b/src/test/java/com/orbitz/consul/model/agent/CheckTest.java
@@ -52,7 +52,7 @@ class CheckTest {
 
     @Test
     void severalArgsCanBeAddedToCheck() {
-        Check check = ImmutableCheck.builder()
+        var check = ImmutableCheck.builder()
                 .id("id")
                 .args(Lists.newArrayList("/bin/echo \"hi\"", "/bin/echo \"hello\""))
                 .interval("1s")
@@ -65,7 +65,7 @@ class CheckTest {
 
     @Test
     void serviceTagsAreNotNullWhenNotSpecified() {
-        Check check = ImmutableCheck.builder()
+        var check = ImmutableCheck.builder()
                 .ttl("")
                 .name("name")
                 .id("id")
@@ -76,7 +76,7 @@ class CheckTest {
 
     @Test
     void serviceTagsCanBeAddedToCheck() {
-        Check check = ImmutableCheck.builder()
+        var check = ImmutableCheck.builder()
                 .ttl("")
                 .name("name")
                 .id("id")

--- a/src/test/java/com/orbitz/consul/model/agent/DebugConfigTest.java
+++ b/src/test/java/com/orbitz/consul/model/agent/DebugConfigTest.java
@@ -241,8 +241,7 @@ class DebugConfigTest {
 
     @Test
     void testDeserialization() throws IOException {
-       ObjectMapper mapper = Jackson.MAPPER;
-       final DebugConfig dbgConfig = mapper.readerFor(DebugConfig.class).readValue(JSON);
-        assertThat(dbgConfig).as("DebugConfig contains 167 items").hasSize(167);
+        var debugConfig = Jackson.MAPPER.readValue(JSON, DebugConfig.class);
+        assertThat(debugConfig).as("DebugConfig contains 167 items").hasSize(167);
     }
 }

--- a/src/test/java/com/orbitz/consul/model/catalog/TaggedAddressesTest.java
+++ b/src/test/java/com/orbitz/consul/model/catalog/TaggedAddressesTest.java
@@ -9,7 +9,7 @@ class TaggedAddressesTest {
 
     @Test
     void buildingTaggedAddressWithAllAttributesShouldSucceed() {
-        ImmutableTaggedAddresses taggedAddresses = ImmutableTaggedAddresses.builder()
+        var taggedAddresses = ImmutableTaggedAddresses.builder()
                 .lan("127.0.0.1")
                 .wan("172.217.17.110")
                 .build();
@@ -20,7 +20,7 @@ class TaggedAddressesTest {
 
     @Test
     void buildingTaggedAddressWithoutLanAddressShouldSucceed() {
-        ImmutableTaggedAddresses taggedAddresses = ImmutableTaggedAddresses.builder()
+        var taggedAddresses = ImmutableTaggedAddresses.builder()
                 .wan("172.217.17.110")
                 .build();
 

--- a/src/test/java/com/orbitz/consul/model/health/HealthCheckTest.java
+++ b/src/test/java/com/orbitz/consul/model/health/HealthCheckTest.java
@@ -9,19 +9,19 @@ class HealthCheckTest {
 
     @Test
     void serviceTagsAreNotNullWhenNotSpecified() {
-        HealthCheck check = ImmutableHealthCheck.builder()
+        var healthCheck = ImmutableHealthCheck.builder()
                 .name("name")
                 .node("node")
                 .checkId("id")
                 .status("passing")
                 .build();
 
-        assertThat(check.getServiceTags()).isEqualTo(List.of());
+        assertThat(healthCheck.getServiceTags()).isEqualTo(List.of());
     }
 
     @Test
     void serviceTagsCanBeAddedToHealthCheck() {
-        HealthCheck check = ImmutableHealthCheck.builder()
+        var healthCheck = ImmutableHealthCheck.builder()
                 .name("name")
                 .node("node")
                 .checkId("id")
@@ -29,6 +29,6 @@ class HealthCheckTest {
                 .addServiceTags("myTag")
                 .build();
 
-        assertThat(check.getServiceTags()).isEqualTo(List.of("myTag"));
+        assertThat(healthCheck.getServiceTags()).isEqualTo(List.of("myTag"));
     }
 }

--- a/src/test/java/com/orbitz/consul/model/health/ServiceTest.java
+++ b/src/test/java/com/orbitz/consul/model/health/ServiceTest.java
@@ -8,18 +8,18 @@ class ServiceTest {
 
     @Test
     void testEquals(){
-        Service one = tagged("a", "b");
-        Service two = tagged("a", "b");
-        assertThat(two).isEqualTo(one);
+        var service1 = newTaggedService("a", "b");
+        var service2 = newTaggedService("a", "b");
+        assertThat(service2).isEqualTo(service1);
     }
 
     @Test
     void testNullTags(){
-        Service sv = tagged();
-        assertThat(sv.getTags()).isEmpty();
+        var service = newTaggedService();
+        assertThat(service.getTags()).isEmpty();
     }
 
-    private Service tagged(String ... tags) {
+    private Service newTaggedService(String ... tags) {
         return ImmutableService
                 .builder()
                 .address("localhost")

--- a/src/test/java/com/orbitz/consul/model/query/FailoverTest.java
+++ b/src/test/java/com/orbitz/consul/model/query/FailoverTest.java
@@ -11,7 +11,7 @@ class FailoverTest {
 
     @Test
     void creatingFailoverWithDatacentersIsValid() {
-        ImmutableFailover failover = ImmutableFailover.builder()
+        var failover = ImmutableFailover.builder()
                 .datacenters(Lists.newArrayList("dc1", "dc2"))
                 .build();
 
@@ -20,7 +20,7 @@ class FailoverTest {
 
     @Test
     void creatingFailoverWithNearestIsValid() {
-        ImmutableFailover failover = ImmutableFailover.builder()
+        var failover = ImmutableFailover.builder()
                 .nearestN(2)
                 .build();
 
@@ -29,7 +29,7 @@ class FailoverTest {
 
     @Test
     void creatingFailoverWithNearestAndDatacentersIsValid() {
-        ImmutableFailover failover = ImmutableFailover.builder()
+        var failover = ImmutableFailover.builder()
                 .datacenters(Lists.newArrayList("dc1", "dc2"))
                 .nearestN(2)
                 .build();

--- a/src/test/java/com/orbitz/consul/option/ConsistencyModeTest.java
+++ b/src/test/java/com/orbitz/consul/option/ConsistencyModeTest.java
@@ -25,7 +25,7 @@ class ConsistencyModeTest {
 
     @Test
     void checkHeadersForCached() {
-        ConsistencyMode consistency = ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(Optional.of(30L), Optional.of(60L));
+        var consistency = ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(Optional.of(30L), Optional.of(60L));
         assertThat(consistency.toParam()).contains("cached");
         assertThat(consistency.getAdditionalHeaders()).hasSize(1);
         assertThat(consistency.getAdditionalHeaders()).containsEntry("Cache-Control", "max-age=30,stale-if-error=60");

--- a/src/test/java/com/orbitz/consul/util/Base64EncodingDeserializerTest.java
+++ b/src/test/java/com/orbitz/consul/util/Base64EncodingDeserializerTest.java
@@ -14,8 +14,8 @@ class Base64EncodingDeserializerTest {
 
     @Test
     void shouldDeserialize() throws IOException {
-        String value = RandomStringUtils.randomAlphabetic(12);
-        Event event = ImmutableEvent.builder()
+        var value = RandomStringUtils.randomAlphabetic(12);
+        var event = ImmutableEvent.builder()
                 .id("1")
                 .lTime(1L)
                 .name("name")

--- a/src/test/java/com/orbitz/consul/util/HttpTest.java
+++ b/src/test/java/com/orbitz/consul/util/HttpTest.java
@@ -59,7 +59,7 @@ class HttpTest {
 
     @Test
     void extractingBodyShouldSucceedWhenRequestSucceed() throws IOException {
-        String expectedBody = "success";
+        var expectedBody = "success";
         Response<String> response = Response.success(expectedBody);
         Call<String> call = createMockCallWithType(String.class);
         when(call.execute()).thenReturn(response);
@@ -82,7 +82,7 @@ class HttpTest {
 
     @Test
     void extractingConsulResponseShouldSucceedWhenRequestSucceed() throws IOException {
-        String expectedBody = "success";
+        var expectedBody = "success";
         Response<String> response = Response.success(expectedBody);
         Call<String> call = createMockCallWithType(String.class);
         when(call.execute()).thenReturn(response);
@@ -243,11 +243,11 @@ class HttpTest {
             public void onFailure(Throwable throwable) {
             }
         };
-        Call<String> call = createMockCallWithType(String.class);
-        Request request = new Request.Builder().url("http://localhost:8500/this/endpoint").build();
+        var call = createMockCallWithType(String.class);
+        var request = new Request.Builder().url("http://localhost:8500/this/endpoint").build();
         when(call.request()).thenReturn(request);
         Callback<String> callCallback = http.createCallback(call, callback);
-        String expectedBody = "success";
+        var expectedBody = "success";
 
         Response<String> response = Response.success(expectedBody);
         callCallback.onResponse(call, response);
@@ -259,8 +259,8 @@ class HttpTest {
 
     @Test
     void extractingConsulResponseAsyncShouldFailWhenRequestIsInvalid() throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        final ConsulResponseCallback<String> callback = new ConsulResponseCallback<>() {
+        var latch = new CountDownLatch(1);
+        var callback = new ConsulResponseCallback<String>() {
             @Override
             public void onComplete(ConsulResponse<String> consulResponse) {
             }
@@ -270,8 +270,8 @@ class HttpTest {
                 latch.countDown();
             }
         };
-        Call<String> call = createMockCallWithType(String.class);
-        Request request = new Request.Builder().url("http://localhost:8500/this/endpoint").build();
+        var call = createMockCallWithType(String.class);
+        var request = new Request.Builder().url("http://localhost:8500/this/endpoint").build();
         when(call.request()).thenReturn(request);
         Callback<String> callCallback = http.createCallback(call, callback);
 
@@ -284,8 +284,8 @@ class HttpTest {
 
     @Test
     void extractingConsulResponseAsyncShouldFailWhenRequestFailed() throws InterruptedException {
-        CountDownLatch latch = new CountDownLatch(1);
-        final ConsulResponseCallback<String> callback = new ConsulResponseCallback<>() {
+        var latch = new CountDownLatch(1);
+        var callback = new ConsulResponseCallback<String>() {
             @Override
             public void onComplete(ConsulResponse<String> consulResponse) {
             }
@@ -295,7 +295,7 @@ class HttpTest {
                 latch.countDown();
             }
         };
-        Call<String> call = createMockCallWithType(String.class);
+        var call = createMockCallWithType(String.class);
         when(call.request()).thenReturn(mock(Request.class));
 
         Callback<String> callCallback = http.createCallback(call, callback);
@@ -313,7 +313,7 @@ class HttpTest {
 
     @Test
     void consulResponseShouldHaveResponseAndDefaultValuesIfNoHeader() {
-        String responseMessage = "success";
+        var responseMessage = "success";
         ConsulResponse<String> expectedConsulResponse = new ConsulResponse<>(responseMessage, 0, false, BigInteger.ZERO, null, null);
 
         Response<String> response = Response.success(responseMessage);

--- a/src/test/java/com/orbitz/consul/util/SecondsSerDeTest.java
+++ b/src/test/java/com/orbitz/consul/util/SecondsSerDeTest.java
@@ -33,25 +33,25 @@ class SecondsSerDeTest {
 
     @Test
     void shouldSerializeSeconds() throws JsonProcessingException {
-        Long seconds = new Random().nextLong();
-        String expected = String.format("\"%ss\"", seconds);
-        String json = OBJECT_MAPPER.writeValueAsString(new Item(seconds));
+        var seconds = new Random().nextLong();
+        var expected = String.format("\"%ss\"", seconds);
+        var json = OBJECT_MAPPER.writeValueAsString(new Item(seconds));
 
         assertThat(json).contains(expected);
     }
 
     @Test
     void shouldDeserializeSeconds() throws IOException {
-        Long seconds = new Random().nextLong();
-        Item item = OBJECT_MAPPER.readValue(String.format("{\"seconds\": \"%ds\"}", seconds), Item.class);
+        var seconds = new Random().nextLong();
+        var item = OBJECT_MAPPER.readValue(String.format("{\"seconds\": \"%ds\"}", seconds), Item.class);
 
         assertThat(item.getSeconds()).isEqualTo(seconds);
     }
 
     @Test
     void shouldDeserializeSeconds_noS() throws IOException {
-        Long seconds = new Random().nextLong();
-        Item item = OBJECT_MAPPER.readValue(String.format("{\"seconds\": \"%d\"}", seconds), Item.class);
+        var seconds = new Random().nextLong();
+        var item = OBJECT_MAPPER.readValue(String.format("{\"seconds\": \"%d\"}", seconds), Item.class);
 
         assertThat(item.getSeconds()).isEqualTo(seconds);
     }

--- a/src/test/java/com/orbitz/consul/util/SecondsSerDeTest.java
+++ b/src/test/java/com/orbitz/consul/util/SecondsSerDeTest.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 class SecondsSerDeTest {
 
@@ -33,7 +33,7 @@ class SecondsSerDeTest {
 
     @Test
     void shouldSerializeSeconds() throws JsonProcessingException {
-        var seconds = new Random().nextLong();
+        var seconds = ThreadLocalRandom.current().nextLong();
         var expected = String.format("\"%ss\"", seconds);
         var json = OBJECT_MAPPER.writeValueAsString(new Item(seconds));
 
@@ -42,7 +42,7 @@ class SecondsSerDeTest {
 
     @Test
     void shouldDeserializeSeconds() throws IOException {
-        var seconds = new Random().nextLong();
+        var seconds = ThreadLocalRandom.current().nextLong();
         var item = OBJECT_MAPPER.readValue(String.format("{\"seconds\": \"%ds\"}", seconds), Item.class);
 
         assertThat(item.getSeconds()).isEqualTo(seconds);
@@ -50,7 +50,7 @@ class SecondsSerDeTest {
 
     @Test
     void shouldDeserializeSeconds_noS() throws IOException {
-        var seconds = new Random().nextLong();
+        var seconds = ThreadLocalRandom.current().nextLong();
         var item = OBJECT_MAPPER.readValue(String.format("{\"seconds\": \"%d\"}", seconds), Item.class);
 
         assertThat(item.getSeconds()).isEqualTo(seconds);

--- a/src/test/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
+++ b/src/test/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
@@ -21,7 +21,7 @@ class BlacklistingConsulFailoverStrategyTest {
     @BeforeEach
     void setup() {
         // Create a set of targets
-        final Collection<HostAndPort> targets = new ArrayList<>();
+        Collection<HostAndPort> targets = new ArrayList<>();
         targets.add(HostAndPort.fromParts("1.2.3.4", 8501));
         targets.add(HostAndPort.fromParts("localhost", 8501));
 
@@ -30,7 +30,7 @@ class BlacklistingConsulFailoverStrategyTest {
 
     @Test
     void getFirstUrlBack() {
-        Request previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+        var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
         Response previousResponse = null;
 
         Optional<Request> result = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
@@ -41,7 +41,7 @@ class BlacklistingConsulFailoverStrategyTest {
 
     @Test
     void getSecondUrlBackAfterFirstOneIsBlacklisted() {
-        Request previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+        var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
         Response previousResponse = null;
 
         Optional<Request> result1 = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
@@ -58,7 +58,7 @@ class BlacklistingConsulFailoverStrategyTest {
 
     @Test
     void getNoUrlBackAfterBothAreBlacklisted() {
-        Request previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+        var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
         Response previousResponse = null;
 
         Optional<Request> result1 = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);


### PR DESCRIPTION
* Use 'var' in unit tests where it makes sense
* Remove 'final' modifier from local variables; it doesn't really add value but does clutter up the code (in terms of readability, subjectively speaking of course)
* Inline the ObjectMapper local variable in DebugConfigTest and use ObjectMapper#readValue so the returned type is correct (not Object)
* Reformatting in KeyValueClient factory
* Other misc reformatting for clarity

Part of #14