### PR TITLE
Additional, miscellaneous cleanup

### DIFF
--- a/src/itest/java/com/orbitz/consul/CatalogITest.java
+++ b/src/itest/java/com/orbitz/consul/CatalogITest.java
@@ -8,7 +8,6 @@ import static org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
 
 import com.orbitz.consul.async.ConsulResponseCallback;
 import com.orbitz.consul.model.ConsulResponse;
-import com.orbitz.consul.model.catalog.CatalogDeregistration;
 import com.orbitz.consul.model.catalog.CatalogNode;
 import com.orbitz.consul.model.catalog.CatalogRegistration;
 import com.orbitz.consul.model.catalog.CatalogService;
@@ -104,9 +103,9 @@ class CatalogITest extends BaseIntegrationTest {
 
     @Test
     void shouldGetTaggedAddressesForNodesLists() {
-        final List<Node> nodesResp = catalogClient.getNodes().getResponse();
+        List<Node> nodesResp = catalogClient.getNodes().getResponse();
         assertThat(nodesResp).isNotEmpty();
-        for (Node node : nodesResp) {
+        for (var node : nodesResp) {
             assertThat(node.getTaggedAddresses()).isNotNull();
             if (node.getTaggedAddresses().isPresent()) {
                 assertThat(node.getTaggedAddresses().get().getWan()).isNotNull();
@@ -117,10 +116,10 @@ class CatalogITest extends BaseIntegrationTest {
 
     @Test
     void shouldGetTaggedAddressesForNode() {
-        final List<Node> nodesResp = catalogClient.getNodes().getResponse();
+        List<Node> nodesResp = catalogClient.getNodes().getResponse();
         assertThat(nodesResp).isNotEmpty();
-        for (Node tmp : nodesResp) {
-            final Node node = catalogClient.getNode(tmp.getNode()).getResponse().getNode();
+        for (var tmpNode : nodesResp) {
+            var node = catalogClient.getNode(tmpNode.getNode()).getResponse().getNode();
             assertThat(node.getTaggedAddresses()).isNotNull();
             if (node.getTaggedAddresses().isPresent()) {
                 assertThat(node.getTaggedAddresses().get().getWan()).isNotNull();
@@ -131,9 +130,9 @@ class CatalogITest extends BaseIntegrationTest {
 
     @Test
     void shouldRegisterService() {
-        String service = randomUUIDString();
-        String serviceId = randomUUIDString();
-        String catalogId = randomUUIDString();
+        var service = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var catalogId = randomUUIDString();
 
         createAndCheckService(
                 ImmutableCatalogService.builder()
@@ -172,9 +171,9 @@ class CatalogITest extends BaseIntegrationTest {
 
     @Test
     void shouldRegisterServiceNoWeights() {
-        String service = randomUUIDString();
-        String serviceId = randomUUIDString();
-        String catalogId = randomUUIDString();
+        var service = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var catalogId = randomUUIDString();
 
         createAndCheckService(
                 ImmutableCatalogService.builder()
@@ -213,11 +212,11 @@ class CatalogITest extends BaseIntegrationTest {
 
     @Test
     void shouldDeregisterWithDefaultDC() {
-        String service = randomUUIDString();
-        String serviceId = randomUUIDString();
-        String catalogId = randomUUIDString();
+        var service = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var catalogId = randomUUIDString();
 
-        CatalogRegistration registration = ImmutableCatalogRegistration.builder()
+        var registration = ImmutableCatalogRegistration.builder()
                 .id(catalogId)
                 .putNodeMeta("a", "b")
                 .address("localhost")
@@ -239,7 +238,7 @@ class CatalogITest extends BaseIntegrationTest {
                 .atMost(FIVE_HUNDRED_MILLISECONDS)
                 .until(() -> serviceExists(service, serviceId));
 
-        CatalogDeregistration deregistration = ImmutableCatalogDeregistration.builder()
+        var deregistration = ImmutableCatalogDeregistration.builder()
                 .node("node")
                 .serviceId(serviceId)
                 .build();
@@ -260,8 +259,8 @@ class CatalogITest extends BaseIntegrationTest {
 
     @Test
     void shouldGetServicesInCallback() throws ExecutionException, InterruptedException, TimeoutException {
-        String serviceName = randomUUIDString();
-        String serviceId = createAutoDeregisterServiceId();
+        var serviceName = randomUUIDString();
+        var serviceId = createAutoDeregisterServiceId();
         client.agentClient().register(20001, 20, serviceName, serviceId, List.of(), Map.of());
 
         CompletableFuture<Map<String, List<String>>> cf = new CompletableFuture<>();
@@ -274,8 +273,8 @@ class CatalogITest extends BaseIntegrationTest {
 
     @Test
     void shouldGetServiceInCallback() throws ExecutionException, InterruptedException, TimeoutException {
-        String serviceName = randomUUIDString();
-        String serviceId = createAutoDeregisterServiceId();
+        var serviceName = randomUUIDString();
+        var serviceId = createAutoDeregisterServiceId();
         client.agentClient().register(20001, 20, serviceName, serviceId, List.of(), Map.of());
 
         CompletableFuture<List<CatalogService>> cf = new CompletableFuture<>();
@@ -291,12 +290,12 @@ class CatalogITest extends BaseIntegrationTest {
 
     @Test
     void shouldGetNodeInCallback() throws ExecutionException, InterruptedException, TimeoutException {
-        String nodeName = "node";
-        String serviceName = randomUUIDString();
-        String serviceId = randomUUIDString();
-        String catalogId = randomUUIDString();
+        var nodeName = "node";
+        var serviceName = randomUUIDString();
+        var serviceId = randomUUIDString();
+        var catalogId = randomUUIDString();
 
-        CatalogRegistration registration = ImmutableCatalogRegistration.builder()
+        var registration = ImmutableCatalogRegistration.builder()
                 .id(catalogId)
                 .putNodeMeta("a", "b")
                 .address("localhost")

--- a/src/itest/java/com/orbitz/consul/LifecycleITest.java
+++ b/src/itest/java/com/orbitz/consul/LifecycleITest.java
@@ -60,6 +60,7 @@ class LifecycleITest extends BaseIntegrationTest {
         assertThat(client.isDestroyed()).isTrue();
     }
 
+    // TODO What to do with this? Delete it, move to documentation. convert it to a test (of something)?
     public static void main(String[] args) {
         var connectionPool = new ConnectionPool();
         var executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 10, TimeUnit.SECONDS,

--- a/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendContext.java
+++ b/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendContext.java
@@ -12,7 +12,7 @@ public class ConsulBookendContext {
     private Map<String, Object> data;
 
     ConsulBookendContext() {
-
+        // package-private constructor
     }
 
     public void put(String key, Object value) {

--- a/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
+++ b/src/test/java/com/orbitz/consul/config/CacheConfigTest.java
@@ -25,7 +25,7 @@ import org.slf4j.Logger;
 import java.math.BigInteger;
 import java.time.Duration;
 import java.time.LocalTime;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
@@ -268,11 +268,7 @@ class CacheConfigTest {
             lastCall = LocalTime.now();
             run++;
 
-            List<Integer> response = new ArrayList<>();
-            for (int i = 0; i < resultCount; i++) {
-                response.add(1);
-            }
-            return response;
+            return Collections.nCopies(resultCount, 1);
         }
     }
 }

--- a/src/test/java/com/orbitz/consul/model/agent/DebugConfigTest.java
+++ b/src/test/java/com/orbitz/consul/model/agent/DebugConfigTest.java
@@ -2,7 +2,6 @@ package com.orbitz.consul.model.agent;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.orbitz.consul.util.Jackson;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
* Replace for loop to fill a list with the same value with Collections#nCopies
* Add TODO in LifecycleITest's main method (yes, which is in a test)
* Remove unused import from DebugConfigTest
* More 'var' in CatalogITest
* Add comment to ConsulBookendContext constructor to clarify constructor is package-private. I missed this when I first saw it and was going to remove it, until I noticed there was no modifier. I am not sure if it needs to stay package-private, but leaving as-is for now. The only reason I can see to make it public is for testing by external code.

Part of #14