### PR TITLE
Clean up HealthITest

### DIFF
--- a/src/itest/java/com/orbitz/consul/HealthITest.java
+++ b/src/itest/java/com/orbitz/consul/HealthITest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigInteger;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 class HealthITest extends BaseIntegrationTest {
 
@@ -36,73 +37,66 @@ class HealthITest extends BaseIntegrationTest {
     @Test
     void shouldFetchPassingNode() throws NotRegisteredException {
         var serviceName = randomUUIDString();
-        var serviceId = randomUUIDString();
+        var serviceId = createAutoDeregisterServiceId();
 
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         agentClient.pass(serviceId);
 
         Consul client2 = builder().withHostAndPort(HostAndPort.fromParts("localhost", consulContainer.getFirstMappedPort())).build();
-        var serviceId2 = randomUUIDString();
+        var serviceId2 = createAutoDeregisterServiceId();
 
         client2.agentClient().register(8080, 20L, serviceName, serviceId2, NO_TAGS, NO_META);
         client2.agentClient().fail(serviceId2);
 
         ConsulResponse<List<ServiceHealth>> response = client2.healthClient().getHealthyServiceInstances(serviceName);
-        assertHealth(serviceId, response);
-
-        agentClient.deregister(serviceId);
-        agentClient.deregister(serviceId2);
+        assertHealthExistsWithServiceId(serviceId, response);
     }
 
     @Test
     void shouldFetchNode() throws NotRegisteredException {
         var serviceName = randomUUIDString();
-        var serviceId = randomUUIDString();
+        var serviceId = createAutoDeregisterServiceId();
 
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         agentClient.pass(serviceId);
 
         ConsulResponse<List<ServiceHealth>> response = client.healthClient().getAllServiceInstances(serviceName);
-        assertHealth(serviceId, response);
-
-        agentClient.deregister(serviceId);
+        assertHealthExistsWithServiceId(serviceId, response);
     }
 
     @Test
     void shouldFetchNodeDatacenter() throws NotRegisteredException {
         var serviceName = randomUUIDString();
-        var serviceId = randomUUIDString();
+        var serviceId = createAutoDeregisterServiceId();
 
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         agentClient.pass(serviceId);
 
         ConsulResponse<List<ServiceHealth>> response = client.healthClient().getAllServiceInstances(serviceName,
                 ImmutableQueryOptions.builder().datacenter("dc1").build());
-        assertHealth(serviceId, response);
-        agentClient.deregister(serviceId);
+        assertHealthExistsWithServiceId(serviceId, response);
     }
 
     @Test
     void shouldFetchNodeBlock() throws NotRegisteredException {
         var serviceName = randomUUIDString();
-        var serviceId = randomUUIDString();
+        var serviceId = createAutoDeregisterServiceId();
 
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         agentClient.pass(serviceId);
 
         ConsulResponse<List<ServiceHealth>> response = client.healthClient().getAllServiceInstances(serviceName,
                 QueryOptions.blockSeconds(2, new BigInteger("0")).datacenter("dc1").build());
-        assertHealth(serviceId, response);
-        agentClient.deregister(serviceId);
+        assertHealthExistsWithServiceId(serviceId, response);
     }
 
     @Test
     void shouldFetchChecksForServiceBlock() throws NotRegisteredException {
         var serviceName = randomUUIDString();
-        var serviceId = randomUUIDString();
+        var serviceId = createAutoDeregisterServiceId();
 
-        Registration.RegCheck check = Registration.RegCheck.ttl(5);
-        Registration registration = ImmutableRegistration
+        var check = Registration.RegCheck.ttl(5);
+        var registration = ImmutableRegistration
                 .builder()
                 .check(check)
                 .port(8080)
@@ -113,54 +107,51 @@ class HealthITest extends BaseIntegrationTest {
         agentClient.register(registration);
         agentClient.pass(serviceId);
 
-        var found = false;
         ConsulResponse<List<HealthCheck>> response = client.healthClient().getServiceChecks(serviceName,
                 QueryOptions.blockSeconds(20, new BigInteger("0")).datacenter("dc1").build());
 
         List<HealthCheck> checks = response.getResponse();
         assertThat(checks).hasSize(1);
-        for(HealthCheck ch : checks) {
-            if(ch.getServiceId().isPresent() && ch.getServiceId().get().equals(serviceId)) {
-                found = true;
-            }
-        }
-        assertThat(found).isTrue();
-        agentClient.deregister(serviceId);
+        assertCheckExistsWithId(checks, serviceId);
     }
 
     @Test
     void shouldFetchByState() throws NotRegisteredException {
         var serviceName = randomUUIDString();
-        var serviceId = randomUUIDString();
+        var serviceId = createAutoDeregisterServiceId();
 
         agentClient.register(8080, 20L, serviceName, serviceId, NO_TAGS, NO_META);
         agentClient.warn(serviceId);
 
-        var found = false;
         ConsulResponse<List<HealthCheck>> response = client.healthClient().getChecksByState(State.WARN);
 
-        for (HealthCheck healthCheck : response.getResponse()) {
-            if (healthCheck.getServiceId().isPresent() && healthCheck.getServiceId().get().equals(serviceId)) {
-                found = true;
-            }
-        }
-
-        assertThat(found).isTrue();
-        agentClient.deregister(serviceId);
+        List<HealthCheck> checks = response.getResponse();
+        assertCheckExistsWithId(checks, serviceId);
     }
 
-    private void assertHealth(String serviceId, ConsulResponse<List<ServiceHealth>> response) {
-        var found = false;
-        List<ServiceHealth> nodes = response.getResponse();
+    private static void assertCheckExistsWithId(List<HealthCheck> checks, String expectedServiceId) {
+        assertThat(checkExistsWithId(checks, expectedServiceId)).isTrue();
+    }
 
-        assertThat(nodes).hasSize(1);
+    private static boolean checkExistsWithId(List<HealthCheck> checks, String expectedServiceId) {
+        return checks.stream()
+                .map(HealthCheck::getServiceId)
+                .filter(Optional::isPresent)
+                .flatMap(Optional::stream)
+                .anyMatch(id -> id.equals(expectedServiceId));
+    }
 
-        for (ServiceHealth health : nodes) {
-            if(health.getService().getId().equals(serviceId)) {
-                found = true;
-            }
-        }
+    private void assertHealthExistsWithServiceId(String serviceId, ConsulResponse<List<ServiceHealth>> response) {
+        List<ServiceHealth> serviceHealthList = response.getResponse();
 
-        assertThat(found).isTrue();
+        assertThat(serviceHealthList).hasSize(1);
+
+        var found = serviceHealthList.stream()
+                .map(serviceHealth -> serviceHealth.getService().getId())
+                .anyMatch(id -> id.equals(serviceId));
+
+        assertThat(found)
+                .describedAs("expected to find ServiceHealth with serviceId %s", serviceId)
+                .isTrue();
     }
 }


### PR DESCRIPTION
* Ensure we deregister by using createAutoDeregisterServiceId when creating service IDs
* Replace verbose and duplicate code to find health checks