### PR TITLE
Fix ConsulBookendContext "useless parameter"

### DIFF
--- a/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendContext.java
+++ b/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendContext.java
@@ -2,7 +2,9 @@ package com.orbitz.consul.util.bookend;
 
 import java.util.Optional;
 
+import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -23,8 +25,20 @@ public class ConsulBookendContext {
         data.put(key, value);
     }
 
-    @SuppressWarnings("unchecked")
     public <T> Optional<T> get(String key, Class<T> klazz) {
-        return Optional.ofNullable((T) data.get(key));
+        if (isNull(data) || !data.containsKey(key)) {
+            return Optional.empty();
+        }
+
+        var object = data.get(key);
+        if (isNull(object)) {
+            return Optional.empty();
+        }
+
+        checkState(klazz.isAssignableFrom(object.getClass()),
+                "Data for key '%s' is not of type: %s", key, klazz.getName());
+
+        T castObject = klazz.cast(object);
+        return Optional.ofNullable(castObject);
     }
 }

--- a/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendContext.java
+++ b/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendContext.java
@@ -4,7 +4,6 @@ import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/com/orbitz/consul/util/bookend/ConsulBookendContextTest.java
+++ b/src/test/java/com/orbitz/consul/util/bookend/ConsulBookendContextTest.java
@@ -1,8 +1,20 @@
 package com.orbitz.consul.util.bookend;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 class ConsulBookendContextTest {
 
@@ -23,5 +35,46 @@ class ConsulBookendContextTest {
 
         var name = context.get("name", String.class).orElseThrow();
         assertThat(name).isEqualTo("TheContext");
+    }
+
+    @Test
+    void shouldReturnEmpty_WhenNoDataHasBeenAdded() {
+        assertThat(context.get("createdAt", Instant.class)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmpty_WhenThereIsNoElementWithSpecifiedKey() {
+        context.put("elapsedMillis", 42L);
+
+        assertThat(context.get("name", String.class)).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmpty_WhenValueIsNull() {
+        context.put("maybeNull", null);
+
+        assertThat(context.get("maybeNull", String.class)).isEmpty();
+    }
+
+    @ParameterizedTest
+    @MethodSource("badDataTypes")
+    void shouldThrowIllegalStateException_WhenDataCannotBeCastToSpecifiedType(String key, Class<?> badType) {
+        context.put("aLong", 42L);
+        context.put("aString", "the value");
+        context.put("anInstant", Instant.now());
+
+        assertThatIllegalStateException()
+                .isThrownBy(() -> context.get(key, badType))
+                .withMessage("Data for key '%s' is not of type: %s", key, badType.getName());
+    }
+
+    static Stream<Arguments> badDataTypes() {
+        return Stream.of(
+            arguments("aLong", Double.class),
+            arguments("aString", List.class),
+            arguments("anInstant", LocalDate.class),
+            arguments("aLong", Integer.class),
+            arguments("aString", Map.class)
+        );
     }
 }


### PR DESCRIPTION
* Use the Class paramter to #get to check whether the value is of the expected; if not throw IllegalStateException with a more informative message
* Improve null and missing data handling in #get
* Use the Class parameter to perform the cast, once we are sure the cast will succeed (this makes the parameter "used")

Fixes #168