### PR TITLE
Convert tabs to spaces

### DIFF
--- a/src/itest/java/com/orbitz/consul/failover/FailoverTest.java
+++ b/src/itest/java/com/orbitz/consul/failover/FailoverTest.java
@@ -13,42 +13,42 @@ class FailoverTest extends BaseIntegrationTest {
 
     /**
      * @implNote Without modifying the production code to allow inspection of interception results, there is no
-	 * way I can see to truly verify whether the blacklisting occurred based on the timeout period. And I don't
-	 * think it's a good idea to modify the production code to allow that, so this test does the best it can.
-	 * In addition, since we're not modifying the production code, there is no "hook" point that would allow
-	 * using Awaitility, so we have to stick with an actual sleep. I did, however, modify the timeout and sleep
-	 * time to be much less than the original 5 seconds. Now the test runs in a little under 500 millis instead
-	 * of over 5 seconds. The main way to verify is to inspect the logged output and check that the first two
-	 * bogus target hosts are tried on both attempts to get peers.
+     * way I can see to truly verify whether the blacklisting occurred based on the timeout period. And I don't
+     * think it's a good idea to modify the production code to allow that, so this test does the best it can.
+     * In addition, since we're not modifying the production code, there is no "hook" point that would allow
+     * using Awaitility, so we have to stick with an actual sleep. I did, however, modify the timeout and sleep
+     * time to be much less than the original 5 seconds. Now the test runs in a little under 500 millis instead
+     * of over 5 seconds. The main way to verify is to inspect the logged output and check that the first two
+     * bogus target hosts are tried on both attempts to get peers.
      */
     @Test
     void testFailover() throws InterruptedException {
 
-		// Create a set of targets
-		var port = consulContainer.getFirstMappedPort();
-		var targets = List.of(
-			HostAndPort.fromParts("1.2.3.4", port),
-			HostAndPort.fromParts("3.4.5.6", port),
-			HostAndPort.fromParts("localhost", port)
-		);
+        // Create a set of targets
+        var port = consulContainer.getFirstMappedPort();
+        var targets = List.of(
+                HostAndPort.fromParts("1.2.3.4", port),
+                HostAndPort.fromParts("3.4.5.6", port),
+                HostAndPort.fromParts("localhost", port)
+        );
 
-		// Create our consul instance
-		var consulBuilder = Consul.builder();
-		var blacklistTimeInMillis = 200;
-		consulBuilder.withMultipleHostAndPort(targets, blacklistTimeInMillis);
-		consulBuilder.withConnectTimeoutMillis(50);
+        // Create our consul instance
+        var consulBuilder = Consul.builder();
+        var blacklistTimeInMillis = 200;
+        consulBuilder.withMultipleHostAndPort(targets, blacklistTimeInMillis);
+        consulBuilder.withConnectTimeoutMillis(50);
 
-		// Create the client
-		Consul client = consulBuilder.build();
+        // Create the client
+        Consul client = consulBuilder.build();
 
-		// Get the peers (should fail through 1.2.3.4 and 3.4.5.6 into localhost)
-		List<String> peers1 = client.statusClient().getPeers();
-		assertThat(peers1).isNotEmpty();
+        // Get the peers (should fail through 1.2.3.4 and 3.4.5.6 into localhost)
+        List<String> peers1 = client.statusClient().getPeers();
+        assertThat(peers1).isNotEmpty();
 
-		Thread.sleep(blacklistTimeInMillis + 1);
+        Thread.sleep(blacklistTimeInMillis + 1);
 
-		// Get the peers again (should fail through 1.2.3.4 and 3.4.5.6 into localhost since the blacklist timeout has expired)
-		List<String> peers2 = client.statusClient().getPeers();
-		assertThat(peers2).isNotEmpty().isEqualTo(peers1);
-	}
+        // Get the peers again (should fail through 1.2.3.4 and 3.4.5.6 into localhost since the blacklist timeout has expired)
+        List<String> peers2 = client.statusClient().getPeers();
+        assertThat(peers2).isNotEmpty().isEqualTo(peers1);
+    }
 }

--- a/src/main/java/com/orbitz/consul/Consul.java
+++ b/src/main/java/com/orbitz/consul/Consul.java
@@ -503,10 +503,10 @@ public class Consul {
          * @return The builder.
          */
         public Builder withFailoverInterceptor(ConsulFailoverStrategy strategy) {
-        	checkArgument(nonNull(strategy), "Must not provide a null strategy");
+            checkArgument(nonNull(strategy), "Must not provide a null strategy");
 
-        	consulFailoverInterceptor = new ConsulFailoverInterceptor(strategy);
-        	return this;
+            consulFailoverInterceptor = new ConsulFailoverInterceptor(strategy);
+            return this;
         }
 
         /**

--- a/src/main/java/com/orbitz/consul/option/DeleteOptions.java
+++ b/src/main/java/com/orbitz/consul/option/DeleteOptions.java
@@ -1,41 +1,41 @@
 package com.orbitz.consul.option;
 
-import java.util.Optional;
+import static com.orbitz.consul.option.Options.optionallyAdd;
+
 import org.immutables.value.Value;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static com.orbitz.consul.option.Options.optionallyAdd;
+import java.util.Optional;
 
 @Value.Immutable
 public abstract class DeleteOptions implements ParamAdder {
 
-	public static final DeleteOptions BLANK = ImmutableDeleteOptions.builder().build();
-	public static final DeleteOptions RECURSE = ImmutableDeleteOptions.builder().recurse(true).build();
+    public static final DeleteOptions BLANK = ImmutableDeleteOptions.builder().build();
+    public static final DeleteOptions RECURSE = ImmutableDeleteOptions.builder().recurse(true).build();
 
-	public abstract Optional<Long> getCas();
+    public abstract Optional<Long> getCas();
 
-	public abstract Optional<Boolean> getRecurse();
+    public abstract Optional<Boolean> getRecurse();
 
-	public abstract Optional<String> getDatacenter();
+    public abstract Optional<String> getDatacenter();
 
-	@Value.Derived
-	public boolean isRecurse() {
-		return getRecurse().isPresent();
-	}
+    @Value.Derived
+    public boolean isRecurse() {
+        return getRecurse().isPresent();
+    }
 
-	@Override
-	public Map<String, Object> toQuery() {
-		final Map<String, Object> result = new HashMap<>();
+    @Override
+    public Map<String, Object> toQuery() {
+        final Map<String, Object> result = new HashMap<>();
 
-		if (isRecurse()) {
-			result.put("recurse", "");
-		}
+        if (isRecurse()) {
+            result.put("recurse", "");
+        }
 
-		optionallyAdd(result, "cas", getCas());
-		optionallyAdd(result, "dc", getDatacenter());
+        optionallyAdd(result, "cas", getCas());
+        optionallyAdd(result, "dc", getDatacenter());
 
-		return result;
-	}
+        return result;
+    }
 }

--- a/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
+++ b/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
@@ -1,83 +1,83 @@
 package com.orbitz.consul.util.failover;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.Optional;
-
-import okhttp3.Interceptor;
-import okhttp3.Request;
-import okhttp3.Response;
-
 import com.google.common.net.HostAndPort;
 import com.orbitz.consul.ConsulException;
 import com.orbitz.consul.util.failover.strategy.BlacklistingConsulFailoverStrategy;
 import com.orbitz.consul.util.failover.strategy.ConsulFailoverStrategy;
-
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Optional;
+
 public class ConsulFailoverInterceptor implements Interceptor {
 
-	private static final Logger LOG = LoggerFactory.getLogger(ConsulFailoverInterceptor.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConsulFailoverInterceptor.class);
 
-	// The consul failover strategy
-	private ConsulFailoverStrategy strategy;
+    // The consul failover strategy
+    private ConsulFailoverStrategy strategy;
 
-	/**
-	 * Default constructor for a set of hosts and ports
-	 * @param targets
-	 */
-	public ConsulFailoverInterceptor(Collection<HostAndPort> targets, long timeout) {
-		this(new BlacklistingConsulFailoverStrategy(targets, timeout));
-	}
+    /**
+     * Default constructor for a set of hosts and ports
+     *
+     * @param targets
+     */
+    public ConsulFailoverInterceptor(Collection<HostAndPort> targets, long timeout) {
+        this(new BlacklistingConsulFailoverStrategy(targets, timeout));
+    }
 
-	/**
-	 * Allows customization of the interceptor chain
-	 * @param strategy
-	 */
-	public ConsulFailoverInterceptor(ConsulFailoverStrategy strategy) {
-		this.strategy = strategy;
-	}
+    /**
+     * Allows customization of the interceptor chain
+     *
+     * @param strategy
+     */
+    public ConsulFailoverInterceptor(ConsulFailoverStrategy strategy) {
+        this.strategy = strategy;
+    }
 
-	@Override
-	public Response intercept(Chain chain) throws IOException {
+    @Override
+    public Response intercept(Chain chain) throws IOException {
 
-		// The original request
-		Request originalRequest = chain.request();
+        // The original request
+        Request originalRequest = chain.request();
 
-		// If it is possible to do a failover on the first request (as in, one or more
-		// targets are viable)
-		if (strategy.isRequestViable(originalRequest)) {
+        // If it is possible to do a failover on the first request (as in, one or more
+        // targets are viable)
+        if (strategy.isRequestViable(originalRequest)) {
 
-			// Initially, we have an inflight request and no response
-			Request previousRequest = originalRequest;
-			Response previousResponse = null;
+            // Initially, we have an inflight request and no response
+            Request previousRequest = originalRequest;
+            Response previousResponse = null;
 
-			Optional<Request> nextRequest;
+            Optional<Request> nextRequest;
 
-			// Get the next viable request
-			while ((nextRequest = strategy.computeNextStage(previousRequest, previousResponse)).isPresent()) {
-				// Get the response from the last viable request
-				try {
+            // Get the next viable request
+            while ((nextRequest = strategy.computeNextStage(previousRequest, previousResponse)).isPresent()) {
+                // Get the response from the last viable request
+                try {
 
-					// Cache for the next cycle if needed
-					final Request next = nextRequest.get();
-					previousRequest = next;
+                    // Cache for the next cycle if needed
+                    final Request next = nextRequest.get();
+                    previousRequest = next;
 
-					// Anything other than an exception is valid here.
-					// This is because a 400 series error is a valid code (Permission Denied/Key Not Found)
-					return chain.proceed(next);
-				} catch (Exception ex) {
-					LOG.debug("Failed to connect to {}", nextRequest.get().url(), ex);
-					strategy.markRequestFailed(nextRequest.get());
-				}
-			}
+                    // Anything other than an exception is valid here.
+                    // This is because a 400 series error is a valid code (Permission Denied/Key Not Found)
+                    return chain.proceed(next);
+                } catch (Exception ex) {
+                    LOG.debug("Failed to connect to {}", nextRequest.get().url(), ex);
+                    strategy.markRequestFailed(nextRequest.get());
+                }
+            }
 
-			throw new ConsulException("Unable to successfully determine a viable host for communication.");
+            throw new ConsulException("Unable to successfully determine a viable host for communication.");
 
-		} else {
-			throw new ConsulException(
-					"Consul failover strategy has determined that there are no viable hosts remaining.");
-		}
-	}
+        } else {
+            throw new ConsulException(
+                    "Consul failover strategy has determined that there are no viable hosts remaining.");
+        }
+    }
 }

--- a/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
@@ -19,106 +19,108 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrategy {
 
-	// The map of blacklisted addresses
-	private Map<HostAndPort, Instant> blacklist = new ConcurrentHashMap<>();
+    // The map of blacklisted addresses
+    private Map<HostAndPort, Instant> blacklist = new ConcurrentHashMap<>();
 
-	// The map of viable targets
-	private Collection<HostAndPort> targets;
+    // The map of viable targets
+    private Collection<HostAndPort> targets;
 
-	// The blacklist timeout
-	private long timeout;
+    // The blacklist timeout
+    private long timeout;
 
-	/**
-	 * Constructs a blacklisting strategy with a collection of hosts and ports
-	 * @param targets A set of viable hosts
-	 * @param timeout The timeout in milliseconds
-	 */
-	public BlacklistingConsulFailoverStrategy(Collection<HostAndPort> targets, long timeout) {
-		this.targets = targets;
-		this.timeout = timeout;
-	}
+    /**
+     * Constructs a blacklisting strategy with a collection of hosts and ports
+     *
+     * @param targets A set of viable hosts
+     * @param timeout The timeout in milliseconds
+     */
+    public BlacklistingConsulFailoverStrategy(Collection<HostAndPort> targets, long timeout) {
+        this.targets = targets;
+        this.timeout = timeout;
+    }
 
-	@Override
-	public Optional<Request> computeNextStage(Request previousRequest, Response previousResponse) {
+    @Override
+    public Optional<Request> computeNextStage(Request previousRequest, Response previousResponse) {
 
-		// Create a host and port
-		final HostAndPort initialTarget = fromRequest(previousRequest);
+        // Create a host and port
+        final HostAndPort initialTarget = fromRequest(previousRequest);
 
-		// If the previous response failed, disallow this request from going through.
-		// A 404 does NOT indicate a failure in this case, so it should never blacklist the previous target.
-		if (previousResponseFailedAndWasNot404(previousResponse)) {
-			this.blacklist.put(initialTarget, Instant.now());
-		}
+        // If the previous response failed, disallow this request from going through.
+        // A 404 does NOT indicate a failure in this case, so it should never blacklist the previous target.
+        if (previousResponseFailedAndWasNot404(previousResponse)) {
+            this.blacklist.put(initialTarget, Instant.now());
+        }
 
-		// If our blacklist contains the target we care about
-		if (blacklist.containsKey(initialTarget)) {
+        // If our blacklist contains the target we care about
+        if (blacklist.containsKey(initialTarget)) {
 
-			// Find the first entity that doesnt exist in the blacklist
-			Optional<HostAndPort> optionalNext = targets.stream().filter(target -> {
+            // Find the first entity that doesnt exist in the blacklist
+            Optional<HostAndPort> optionalNext = targets.stream().filter(target -> {
 
-				// If we have blacklisted this key
-				if (blacklist.containsKey(target)) {
+                // If we have blacklisted this key
+                if (blacklist.containsKey(target)) {
 
-					// Get when we blacklisted this key
-					final Instant blacklistedAt = blacklist.get(target);
+                    // Get when we blacklisted this key
+                    final Instant blacklistedAt = blacklist.get(target);
 
-					// If the duration between the blacklist time ("then") and "now" is greater than the
-					// timeout duration (Duration(then, now) - timeout < 0), then remove the blacklist entry
-					if (Duration.between(blacklistedAt, Instant.now()).minusMillis(timeout).isNegative()) {
-						return false;
-					} else {
-						blacklist.remove(target);
-						return true;
-					}
-				} else {
-					return true;
-				}
-			}).findAny();
+                    // If the duration between the blacklist time ("then") and "now" is greater than the
+                    // timeout duration (Duration(then, now) - timeout < 0), then remove the blacklist entry
+                    if (Duration.between(blacklistedAt, Instant.now()).minusMillis(timeout).isNegative()) {
+                        return false;
+                    } else {
+                        blacklist.remove(target);
+                        return true;
+                    }
+                } else {
+                    return true;
+                }
+            }).findAny();
 
-			if (optionalNext.isEmpty()) {
-				return Optional.empty();
-			}
-			HostAndPort next = optionalNext.get();
+            if (optionalNext.isEmpty()) {
+                return Optional.empty();
+            }
+            HostAndPort next = optionalNext.get();
 
-			// Construct the next URL using the old parameters (ensures we don't have to do
-			// a copy-on-write
-			final HttpUrl nextURL = previousRequest.url().newBuilder().host(next.getHost()).port(next.getPort()).build();
+            // Construct the next URL using the old parameters (ensures we don't have to do
+            // a copy-on-write
+            final HttpUrl nextURL = previousRequest.url().newBuilder().host(next.getHost()).port(next.getPort()).build();
 
-			// Return the result
-			return Optional.ofNullable(previousRequest.newBuilder().url(nextURL).build());
-		} else {
+            // Return the result
+            return Optional.ofNullable(previousRequest.newBuilder().url(nextURL).build());
+        } else {
 
-			// Construct the next URL using the old parameters (ensures we don't have to do
-			// a copy-on-write
-			final HttpUrl nextURL = previousRequest.url().newBuilder().host(initialTarget.getHost()).port(initialTarget.getPort()).build();
+            // Construct the next URL using the old parameters (ensures we don't have to do
+            // a copy-on-write
+            final HttpUrl nextURL = previousRequest.url().newBuilder().host(initialTarget.getHost()).port(initialTarget.getPort()).build();
 
-			// Return the result
-			return Optional.ofNullable(previousRequest.newBuilder().url(nextURL).build());
-		}
+            // Return the result
+            return Optional.ofNullable(previousRequest.newBuilder().url(nextURL).build());
+        }
 
-	}
+    }
 
-	private static boolean previousResponseFailedAndWasNot404(Response previousResponse) {
-		return nonNull(previousResponse) && !previousResponse.isSuccessful() && previousResponse.code() != 404;
-	}
+    private static boolean previousResponseFailedAndWasNot404(Response previousResponse) {
+        return nonNull(previousResponse) && !previousResponse.isSuccessful() && previousResponse.code() != 404;
+    }
 
-	@Override
-	public boolean isRequestViable(Request current) {
-		return (targets.size() > blacklist.size()) || !blacklist.containsKey(fromRequest(current));
-	}
+    @Override
+    public boolean isRequestViable(Request current) {
+        return (targets.size() > blacklist.size()) || !blacklist.containsKey(fromRequest(current));
+    }
 
-	@Override
-	public void markRequestFailed(Request current) {
-		this.blacklist.put(fromRequest(current), Instant.now());
-	}
+    @Override
+    public void markRequestFailed(Request current) {
+        this.blacklist.put(fromRequest(current), Instant.now());
+    }
 
-	/**
-	 * Reconstructs a HostAndPort instance from the request object
-	 * @param request
-	 * @return
-	 */
-	private HostAndPort fromRequest(Request request) {
-		return HostAndPort.fromParts(request.url().host(), request.url().port());
-	}
+    /**
+     * Reconstructs a HostAndPort instance from the request object
+     *
+     * @param request
+     * @return
+     */
+    private HostAndPort fromRequest(Request request) {
+        return HostAndPort.fromParts(request.url().host(), request.url().port());
+    }
 
 }

--- a/src/main/java/com/orbitz/consul/util/failover/strategy/ConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/ConsulFailoverStrategy.java
@@ -1,41 +1,43 @@
 package com.orbitz.consul.util.failover.strategy;
 
+import okhttp3.Request;
+import okhttp3.Response;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Optional;
 
-import okhttp3.Request;
-import okhttp3.Response;
-
 public interface ConsulFailoverStrategy {
 
 
-	/**
-	 * Computes the next failover stage for the consul failover strategy. This allows the end user to customize the way
-	 * and methods by which additional failover targets may be selected.
-	 * @param previousRequest The last request to go out the door.
-	 * @param previousResponse The response that returned when previousRequest was completed.
-	 * @return An optional failover request. This may return an empty optional, signaling that the request should be aborted
-	 */
-	@NonNull
-	public Optional<Request> computeNextStage(@NonNull Request previousRequest, @Nullable Response previousResponse);
+    /**
+     * Computes the next failover stage for the consul failover strategy. This allows the end user to customize the way
+     * and methods by which additional failover targets may be selected.
+     *
+     * @param previousRequest  The last request to go out the door.
+     * @param previousResponse The response that returned when previousRequest was completed.
+     * @return An optional failover request. This may return an empty optional, signaling that the request should be aborted
+     */
+    @NonNull
+    public Optional<Request> computeNextStage(@NonNull Request previousRequest, @Nullable Response previousResponse);
 
-	/**
-	 * Determines if there is a viable candidate for the next request. This lets us short circuit the first attempted request
-	 * (such as when we know with certainty that a host should not be available) without interfering with the consul client too
-	 * much.
-	 * @param current The current inflight request.
-	 * @return A boolean representing if there is another possible request candidate available.
-	 */
-	public boolean isRequestViable(@NonNull Request current);
+    /**
+     * Determines if there is a viable candidate for the next request. This lets us short circuit the first attempted request
+     * (such as when we know with certainty that a host should not be available) without interfering with the consul client too
+     * much.
+     *
+     * @param current The current inflight request.
+     * @return A boolean representing if there is another possible request candidate available.
+     */
+    public boolean isRequestViable(@NonNull Request current);
 
-	/**
-	 * Marks the specified request as a failed URL (in case of exceptions and other events that could cause
-	 * us to never get a response. This avoids infinite loops where the strategy can never be made aware that the request
-	 * has failed.
-	 * @param current The current request object representing a request that failed
-	 */
-	public void markRequestFailed(@NonNull Request current);
+    /**
+     * Marks the specified request as a failed URL (in case of exceptions and other events that could cause
+     * us to never get a response. This avoids infinite loops where the strategy can never be made aware that the request
+     * has failed.
+     *
+     * @param current The current request object representing a request that failed
+     */
+    public void markRequestFailed(@NonNull Request current);
 
 }


### PR DESCRIPTION
The following files still had some tabs or were all tabs. They were all converted back to spaces.

* FailoverTest
* DeleteOptions
* BlacklistingConsulFailoverStrategy
* ConsulFailoverInterceptor
* ConsulFailoverInterceptor
* Consul

IntelliJ also decided to fix some imports and add some blank lines in javadoc between the main
text and the params.

Closes #166