### PR TITLE
Remove "main" method from LifecycleITest

### DIFF
--- a/src/itest/java/com/orbitz/consul/LifecycleITest.java
+++ b/src/itest/java/com/orbitz/consul/LifecycleITest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
@@ -16,6 +18,8 @@ import okhttp3.ConnectionPool;
 import okhttp3.internal.Util;
 
 class LifecycleITest extends BaseIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LifecycleITest.class);
 
     @Test
     void shouldBeDestroyable() {
@@ -40,6 +44,7 @@ class LifecycleITest extends BaseIntegrationTest {
 
         client.destroy();
 
+        assertThat(client.isDestroyed()).isTrue();
         verify(executorService).shutdownNow();
         verifyNoMoreInteractions(executorService);
     }
@@ -47,38 +52,27 @@ class LifecycleITest extends BaseIntegrationTest {
     @Test
     void shouldBeDestroyableWithCustomExecutorService() throws InterruptedException {
         var connectionPool = new ConnectionPool();
+        var workQueue = new SynchronousQueue<Runnable>();
+        var threadFactory = Util.threadFactory("OkHttp Dispatcher", false);
         var executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60, TimeUnit.SECONDS,
-                new SynchronousQueue<>(), Util.threadFactory("OkHttp Dispatcher", false));
+                workQueue, threadFactory);
 
         executorService.execute(() -> {
-            Thread currentThread = Thread.currentThread();
-            System.out.println("This is a Task printing a message in Thread " + currentThread);
+            var currentThread = Thread.currentThread();
+            LOG.info("This is a Task printing a message in Thread {}", currentThread);
         });
-        Consul client = Consul.builder().withHostAndPort(defaultClientHostAndPort)
-            .withExecutorService(executorService).withConnectionPool(connectionPool).build();
+
+        Consul client = Consul.builder()
+                .withHostAndPort(defaultClientHostAndPort)
+                .withExecutorService(executorService)
+                .withConnectionPool(connectionPool)
+                .build();
+
         client.destroy();
+
         assertThat(client.isDestroyed()).isTrue();
+
+        boolean wasTerminated = executorService.awaitTermination(1, TimeUnit.SECONDS);
+        assertThat(wasTerminated).isTrue();
     }
-
-    public static void main(String[] args) {
-        var connectionPool = new ConnectionPool();
-        var executorService = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 10, TimeUnit.SECONDS,
-                new SynchronousQueue<>(), Util.threadFactory("OkHttp Dispatcher", false));
-
-        // execute a task in order to force the creation of a Thread in the ThreadPool
-        executorService.execute(() -> {
-            Thread currentThread = Thread.currentThread();
-            System.out.println("This is a Task printing a message in Thread " + currentThread);
-        });
-
-        Consul client = Consul.builder().withHostAndPort(defaultClientHostAndPort)
-            .withExecutorService(executorService).withConnectionPool(connectionPool).build();
-
-        // do not destroy the Consul client
-        // in order to verify that the Java VM does not terminate, and waits for some time (keepAliveTime parameter of the ThreadPoolExecutor)
-        // if we call destroy() then the JVM terminates immediately
-
-        //client.destroy();
-    }
-
 }


### PR DESCRIPTION
* Remove the main method
* Clean up tests a little bit
* Add more assertions, e.g. client was destroyed, executor was shut down
* Change from a System.out.println to a Logger (though, I am not sure what the purpose of executing the task actually is...)

Closes #172