### PR TITLE
Remove unused parameter from method in Http class

### DIFF
--- a/src/main/java/com/orbitz/consul/util/Http.java
+++ b/src/main/java/com/orbitz/consul/util/Http.java
@@ -66,14 +66,13 @@ public class Http {
         }
     }
 
-    public <T> void extractConsulResponse(Call<T> call, final ConsulResponseCallback<T> callback,
-                                                 final Integer... okCodes) {
-        call.enqueue(createCallback(call, callback, okCodes));
+    public <T> void extractConsulResponse(Call<T> call, ConsulResponseCallback<T> callback, Integer... okCodes) {
+        var retrofitCallback = createRetrofitCallback(callback, okCodes);
+        call.enqueue(retrofitCallback);
     }
 
     @VisibleForTesting
-    <T> retrofit2.Callback<T> createCallback(Call<T> call, final ConsulResponseCallback<T> callback,
-                                             final Integer... okCodes) {
+    <T> retrofit2.Callback<T> createRetrofitCallback(ConsulResponseCallback<T> callback, Integer... okCodes) {
         return new retrofit2.Callback<T>() {
             @Override
             public void onResponse(Call<T> call, Response<T> response) {

--- a/src/test/java/com/orbitz/consul/util/HttpTest.java
+++ b/src/test/java/com/orbitz/consul/util/HttpTest.java
@@ -246,11 +246,11 @@ class HttpTest {
         var call = createMockCallWithType(String.class);
         var request = new Request.Builder().url("http://localhost:8500/this/endpoint").build();
         when(call.request()).thenReturn(request);
-        Callback<String> callCallback = http.createCallback(call, callback);
+        Callback<String> retrofitCallback = http.createRetrofitCallback(callback);
         var expectedBody = "success";
 
         Response<String> response = Response.success(expectedBody);
-        callCallback.onResponse(call, response);
+        retrofitCallback.onResponse(call, response);
         latch.await(1, TimeUnit.SECONDS);
 
         assertThat(result.get().getResponse()).isEqualTo(expectedBody);
@@ -273,10 +273,10 @@ class HttpTest {
         var call = createMockCallWithType(String.class);
         var request = new Request.Builder().url("http://localhost:8500/this/endpoint").build();
         when(call.request()).thenReturn(request);
-        Callback<String> callCallback = http.createCallback(call, callback);
+        Callback<String> retrofitCallback = http.createRetrofitCallback(callback);
 
         Response<String> response = Response.error(400, ResponseBody.create("failure", MediaType.parse("")));
-        callCallback.onResponse(call, response);
+        retrofitCallback.onResponse(call, response);
         latch.await(1, TimeUnit.SECONDS);
 
         verify(clientEventHandler, only()).httpRequestInvalid(any(Request.class), any(Throwable.class));
@@ -298,9 +298,9 @@ class HttpTest {
         var call = createMockCallWithType(String.class);
         when(call.request()).thenReturn(mock(Request.class));
 
-        Callback<String> callCallback = http.createCallback(call, callback);
+        Callback<String> retrofitCallback = http.createRetrofitCallback(callback);
 
-        callCallback.onFailure(call, new RuntimeException("the request failed"));
+        retrofitCallback.onFailure(call, new RuntimeException("the request failed"));
 
         latch.await(1, TimeUnit.SECONDS);
         verify(clientEventHandler, only()).httpRequestFailure(any(Request.class), any(Throwable.class));


### PR DESCRIPTION
* Remove unused Call<T> parameter from createCallback
* Rename createCallback to createRetrofitCallback to more clearly distringuish between the Retrofit Callback and the ConsulResponseCallback, (it's callbacks all the way down)
* Remove extraneous `final` modifiers from method arguments (yes, I have read Effective Java, and while technically correct it's a bit much in real code and clutters the code up a lot, in my opinion of course...)
* Rename local vars in HttpTest from callCallback to retrofitCallback for what should be obvious reasons...

Closes #173