### PR TITLE
Rename "ignored" ConsulExceptions in KeyValueClient

### DIFF
--- a/src/itest/java/com/orbitz/consul/KeyValueITest.java
+++ b/src/itest/java/com/orbitz/consul/KeyValueITest.java
@@ -530,4 +530,16 @@ class KeyValueITest extends BaseIntegrationTest {
         List<String> shouldBeEmpty = keyValueClient.getKeys("unknownKey");
         assertThat(shouldBeEmpty).isEmpty();
     }
+
+    @Test
+    void shouldReturnEmptyOptional_WhenGetValue_WithUnknownKey() {
+        var valueOptional = keyValueClient.getValue("unknownKey", QueryOptions.BLANK);
+        assertThat(valueOptional).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmptyOptional_WhenGetConsulResponseWithValue_WithUnknownKey() {
+        var consulResponseOptional = keyValueClient.getConsulResponseWithValue("unknownKey", QueryOptions.BLANK);
+        assertThat(consulResponseOptional).isEmpty();
+    }
 }

--- a/src/test/java/com/orbitz/consul/KeyValueClientTest.java
+++ b/src/test/java/com/orbitz/consul/KeyValueClientTest.java
@@ -1,0 +1,75 @@
+package com.orbitz.consul;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.orbitz.consul.config.ClientConfig;
+import com.orbitz.consul.monitoring.NoOpClientEventCallback;
+import com.orbitz.consul.option.QueryOptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import retrofit2.Response;
+
+class KeyValueClientTest {
+
+    private KeyValueClient keyValueClient;
+    private KeyValueClient.Api api;
+
+    @BeforeEach
+    void setUp() {
+        api = mock(KeyValueClient.Api.class);
+        var networkTimeoutConfig = new Consul.NetworkTimeoutConfig.Builder().build();
+        keyValueClient = new KeyValueClient(api, new ClientConfig(), new NoOpClientEventCallback(), networkTimeoutConfig);
+    }
+
+    @Nested
+    class GetValue {
+
+        @Test
+        void shouldReturnEmptyOptional_WhenConsulException_HasStatusCode_404() {
+            var consulException = new ConsulException(404, mock(Response.class));
+            when(api.getValue(anyString(), anyMap())).thenThrow(consulException);
+
+            assertThat(keyValueClient.getValue("someKey", QueryOptions.BLANK)).isEmpty();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 401, 403, 500, 502, 503 })
+        void shouldRethrowConsulException_WhenItHasStatusCode_OtherThan404(int statusCode) {
+            var consulException = new ConsulException(statusCode, mock(Response.class));
+            when(api.getValue(anyString(), anyMap())).thenThrow(consulException);
+
+            assertThatThrownBy(() -> keyValueClient.getValue("someKey", QueryOptions.BLANK))
+                    .isSameAs(consulException);
+        }
+    }
+
+    @Nested
+    class GetConsulResponseWithValue {
+
+        @Test
+        void shouldReturnEmptyOptional_WhenConsulException_HasStatusCode_404() {
+            var consulException = new ConsulException(404, mock(Response.class));
+            when(api.getValue(anyString(), anyMap())).thenThrow(consulException);
+
+            assertThat(keyValueClient.getConsulResponseWithValue("someKey", QueryOptions.BLANK)).isEmpty();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 401, 403, 500, 502, 503 })
+        void shouldRethrowConsulException_WhenItHasStatusCode_OtherThan404(int statusCode) {
+            var consulException = new ConsulException(statusCode, mock(Response.class));
+            when(api.getValue(anyString(), anyMap())).thenThrow(consulException);
+
+            assertThatThrownBy(() -> keyValueClient.getConsulResponseWithValue("someKey", QueryOptions.BLANK))
+                    .isSameAs(consulException);
+        }
+    }
+}


### PR DESCRIPTION
* Rename the ConsulException from "ignored" to "e". Naming a parameter "ignored" is confusing since it usually indicates the value is ignored for some reason. In this case it is definitely not ignored.
* Extract local variables from the embedded expressions inside the `getValue` and `getConsulResponseWithValue` methods to make the code more readable by humans

Closes #153