### PR TITLE
Rename integration tests so IDEs can easily find them

### DIFF
--- a/src/itest/java/com/orbitz/consul/AclClientITest.java
+++ b/src/itest/java/com/orbitz/consul/AclClientITest.java
@@ -23,9 +23,10 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 
-class AclTest {
+class AclClientITest {
 
     public static GenericContainer<?> consulContainerAcl;
+
     static {
         consulContainerAcl = new GenericContainer<>("consul")
                 .withCommand("agent", "-dev", "-client", "0.0.0.0", "--enable-script-checks=true")

--- a/src/itest/java/com/orbitz/consul/AgentClientITest.java
+++ b/src/itest/java/com/orbitz/consul/AgentClientITest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-class AgentITest extends BaseIntegrationTest {
+class AgentClientITest extends BaseIntegrationTest {
 
     private static final List<String> NO_TAGS = List.of();
     private static final Map<String, String> NO_META = Map.of();

--- a/src/itest/java/com/orbitz/consul/CatalogClientITest.java
+++ b/src/itest/java/com/orbitz/consul/CatalogClientITest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
-class CatalogITest extends BaseIntegrationTest {
+class CatalogClientITest extends BaseIntegrationTest {
 
     private CatalogClient catalogClient;
 

--- a/src/itest/java/com/orbitz/consul/CoordinateClientITest.java
+++ b/src/itest/java/com/orbitz/consul/CoordinateClientITest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-class CoordinateITest extends BaseIntegrationTest {
+class CoordinateClientITest extends BaseIntegrationTest {
 
     @Test
     void shouldGetDatacenters() {

--- a/src/itest/java/com/orbitz/consul/EventClientITest.java
+++ b/src/itest/java/com/orbitz/consul/EventClientITest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.atomic.AtomicReference;
 
-class EventITest extends BaseIntegrationTest {
+class EventClientITest extends BaseIntegrationTest {
 
     private EventClient eventClient;
 

--- a/src/itest/java/com/orbitz/consul/HealthClientITest.java
+++ b/src/itest/java/com/orbitz/consul/HealthClientITest.java
@@ -13,7 +13,6 @@ import com.orbitz.consul.model.health.HealthCheck;
 import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.option.ImmutableQueryOptions;
 import com.orbitz.consul.option.QueryOptions;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-class HealthITest extends BaseIntegrationTest {
+class HealthClientITest extends BaseIntegrationTest {
 
     private static final List<String> NO_TAGS = List.of();
     private static final Map<String, String> NO_META = Map.of();

--- a/src/itest/java/com/orbitz/consul/KeyValueClientITest.java
+++ b/src/itest/java/com/orbitz/consul/KeyValueClientITest.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-class KeyValueITest extends BaseIntegrationTest {
+class KeyValueClientITest extends BaseIntegrationTest {
 
     private static final Charset TEST_CHARSET = Charset.forName("IBM297");
 

--- a/src/itest/java/com/orbitz/consul/OperatorClientITest.java
+++ b/src/itest/java/com/orbitz/consul/OperatorClientITest.java
@@ -3,13 +3,12 @@ package com.orbitz.consul;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.orbitz.consul.model.operator.RaftServer;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-class OperatorITest extends BaseIntegrationTest {
+class OperatorClientITest extends BaseIntegrationTest {
 
     private OperatorClient operatorClient;
 

--- a/src/itest/java/com/orbitz/consul/PreparedQueryClientITest.java
+++ b/src/itest/java/com/orbitz/consul/PreparedQueryClientITest.java
@@ -10,7 +10,6 @@ import com.orbitz.consul.model.query.ImmutablePreparedQuery;
 import com.orbitz.consul.model.query.ImmutableServiceQuery;
 import com.orbitz.consul.model.query.PreparedQuery;
 import com.orbitz.consul.model.query.StoredQuery;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-class PreparedQueryITest extends BaseIntegrationTest {
+class PreparedQueryClientITest extends BaseIntegrationTest {
 
     private PreparedQueryClient preparedQueryClient;
     private List<String> queryIdsToDelete;


### PR DESCRIPTION
Rename several integration tests so the test class name includes the class under test, which allows IDEs to find them using typical naming conventions. For example, rename AclITest to AclClientITest since it is an integration test of the AclClient.