### PR TITLE
Cleanup: Make fields final and remove unnecessary throws declarations

### DIFF
--- a/src/itest/java/com/orbitz/consul/LifecycleITest.java
+++ b/src/itest/java/com/orbitz/consul/LifecycleITest.java
@@ -5,6 +5,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import okhttp3.ConnectionPool;
+import okhttp3.internal.Util;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -13,9 +15,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-
-import okhttp3.ConnectionPool;
-import okhttp3.internal.Util;
 
 class LifecycleITest extends BaseIntegrationTest {
 
@@ -32,7 +31,7 @@ class LifecycleITest extends BaseIntegrationTest {
     }
 
     @Test
-    void shouldDestroyTheExecutorServiceWhenDestroyMethodIsInvoked() throws InterruptedException {
+    void shouldDestroyTheExecutorServiceWhenDestroyMethodIsInvoked() {
         var connectionPool = new ConnectionPool();
         var executorService = mock(ExecutorService.class);
 

--- a/src/itest/java/com/orbitz/consul/StatusClientITest.java
+++ b/src/itest/java/com/orbitz/consul/StatusClientITest.java
@@ -1,5 +1,8 @@
 package com.orbitz.consul;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.net.HostAndPort;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -15,15 +18,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import com.google.common.net.HostAndPort;
-
 class StatusClientITest extends BaseIntegrationTest {
 
-    private static Logger LOG = LoggerFactory.getLogger(StatusClientITest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(StatusClientITest.class);
 
-    private static Set<InetAddress> ips = new HashSet<>();
+    private static final Set<InetAddress> ips = new HashSet<>();
 
     @BeforeAll
     static void getIps() throws RuntimeException {

--- a/src/itest/java/com/orbitz/consul/cache/KVCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/KVCacheITest.java
@@ -52,7 +52,7 @@ class KVCacheITest extends BaseIntegrationTest {
     }
 
     @Test
-    void nodeCacheKvTest() throws Exception {
+    void nodeCacheKvTest() {
         var root = randomUUIDString();
 
         for (int i = 0; i < 5; i++) {
@@ -99,7 +99,7 @@ class KVCacheITest extends BaseIntegrationTest {
     }
 
     @Test
-    void testListeners() throws Exception {
+    void testListeners() {
         var root = randomUUIDString();
         final List<Map<String, Value>> events = new ArrayList<>();
 
@@ -139,7 +139,7 @@ class KVCacheITest extends BaseIntegrationTest {
     }
 
     @Test
-    void testLateListenersGetValues() throws Exception {
+    void testLateListenersGetValues() {
         var root = randomUUIDString();
 
         try (var cache = KVCache.newCache(kvClient, root, 10)) {
@@ -172,7 +172,7 @@ class KVCacheITest extends BaseIntegrationTest {
     }
 
     @Test
-    void testListenersNonExistingKeys() throws Exception {
+    void testListenersNonExistingKeys() {
         var root = randomUUIDString();
 
         try (var cache = KVCache.newCache(kvClient, root, 10)) {
@@ -193,7 +193,7 @@ class KVCacheITest extends BaseIntegrationTest {
     }
 
     @Test
-    void testLifeCycleDoubleStart() throws Exception {
+    void testLifeCycleDoubleStart() {
         var root = randomUUIDString();
 
         try (var cache = KVCache.newCache(kvClient, root, 10)) {
@@ -211,12 +211,11 @@ class KVCacheITest extends BaseIntegrationTest {
     }
 
     @Test
-    void testLifeCycle() throws Exception {
+    void testLifeCycle() {
         var root = randomUUIDString();
         final List<Map<String, Value>> events = new ArrayList<>();
 
         // intentionally not using try-with-resources to test the cache lifecycle methods
-        // noinspection resource
         var cache = KVCache.newCache(kvClient, root, 10);
 
         try {

--- a/src/itest/java/com/orbitz/consul/util/CustomBuilderITest.java
+++ b/src/itest/java/com/orbitz/consul/util/CustomBuilderITest.java
@@ -7,12 +7,11 @@ import com.orbitz.consul.Consul;
 import org.junit.jupiter.api.Test;
 
 import java.net.Proxy;
-import java.net.UnknownHostException;
 
 class CustomBuilderITest extends BaseIntegrationTest{
 
     @Test
-    void shouldConnectWithCustomTimeouts() throws UnknownHostException {
+    void shouldConnectWithCustomTimeouts() {
         var client = Consul.builder()
                 .withHostAndPort(defaultClientHostAndPort)
                 .withProxy(Proxy.NO_PROXY)

--- a/src/main/java/com/orbitz/consul/cache/TimeoutInterceptor.java
+++ b/src/main/java/com/orbitz/consul/cache/TimeoutInterceptor.java
@@ -8,7 +8,6 @@ import com.orbitz.consul.config.CacheConfig;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
-
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +20,7 @@ public class TimeoutInterceptor implements Interceptor {
 
     private static final Logger LOG = LoggerFactory.getLogger(TimeoutInterceptor.class);
 
-    private CacheConfig config;
+    private final CacheConfig config;
 
     public TimeoutInterceptor(CacheConfig config) {
         this.config = config;

--- a/src/main/java/com/orbitz/consul/model/acl/TokenType.java
+++ b/src/main/java/com/orbitz/consul/model/acl/TokenType.java
@@ -4,7 +4,7 @@ public enum TokenType {
 
     CLIENT("client"), MANAGEMENT("management");
 
-    private String display;
+    private final String display;
 
     TokenType(String display) {
         this.display = display;

--- a/src/main/java/com/orbitz/consul/model/kv/Verb.java
+++ b/src/main/java/com/orbitz/consul/model/kv/Verb.java
@@ -6,7 +6,7 @@ public enum Verb {
     GET_TREE("get-tree"), CHECK_INDEX("check-index"), CHECK_SESSION("check-session"),
     DELETE("delete"), DELETE_TREE("delete-tree"), DELETE_CHECK_AND_SET("delete-cas");
 
-    private String value;
+    private final String value;
 
     Verb(String value) {
         this.value = value;

--- a/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendInterceptor.java
+++ b/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendInterceptor.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 
 public class ConsulBookendInterceptor implements Interceptor {
 
-    private ConsulBookend consulBookend;
+    private final ConsulBookend consulBookend;
 
     public ConsulBookendInterceptor(ConsulBookend consulBookend) {
         this.consulBookend = consulBookend;

--- a/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
+++ b/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
@@ -10,7 +10,6 @@ import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Optional;
 
@@ -19,12 +18,12 @@ public class ConsulFailoverInterceptor implements Interceptor {
     private static final Logger LOG = LoggerFactory.getLogger(ConsulFailoverInterceptor.class);
 
     // The consul failover strategy
-    private ConsulFailoverStrategy strategy;
+    private final ConsulFailoverStrategy strategy;
 
     /**
      * Default constructor for a set of hosts and ports
      *
-     * @param targets
+     * @param targets the host/port pairs to use for failover
      */
     public ConsulFailoverInterceptor(Collection<HostAndPort> targets, long timeout) {
         this(new BlacklistingConsulFailoverStrategy(targets, timeout));
@@ -33,14 +32,14 @@ public class ConsulFailoverInterceptor implements Interceptor {
     /**
      * Allows customization of the interceptor chain
      *
-     * @param strategy
+     * @param strategy the failover strategy
      */
     public ConsulFailoverInterceptor(ConsulFailoverStrategy strategy) {
         this.strategy = strategy;
     }
 
     @Override
-    public Response intercept(Chain chain) throws IOException {
+    public Response intercept(Chain chain) {
 
         // The original request
         Request originalRequest = chain.request();

--- a/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
@@ -20,13 +20,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrategy {
 
     // The map of blacklisted addresses
-    private Map<HostAndPort, Instant> blacklist = new ConcurrentHashMap<>();
+    private final Map<HostAndPort, Instant> blacklist = new ConcurrentHashMap<>();
 
     // The map of viable targets
-    private Collection<HostAndPort> targets;
+    private final Collection<HostAndPort> targets;
 
     // The blacklist timeout
-    private long timeout;
+    private final long timeout;
 
     /**
      * Constructs a blacklisting strategy with a collection of hosts and ports

--- a/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/KVCacheTest.java
@@ -15,11 +15,14 @@ import com.orbitz.consul.config.ClientConfig;
 import com.orbitz.consul.model.kv.ImmutableValue;
 import com.orbitz.consul.model.kv.Value;
 import com.orbitz.consul.monitoring.NoOpClientEventCallback;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import retrofit2.Retrofit;
+import retrofit2.mock.BehaviorDelegate;
+import retrofit2.mock.MockRetrofit;
+import retrofit2.mock.NetworkBehavior;
 
 import java.time.Duration;
 import java.util.Optional;
@@ -27,11 +30,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Stream;
-
-import retrofit2.Retrofit;
-import retrofit2.mock.BehaviorDelegate;
-import retrofit2.mock.MockRetrofit;
-import retrofit2.mock.NetworkBehavior;
 
 class KVCacheTest {
 
@@ -73,7 +71,7 @@ class KVCacheTest {
     }
 
     @Test
-    void testListenerWithMockRetrofit() throws InterruptedException {
+    void testListenerWithMockRetrofit() {
         var retrofit = new Retrofit.Builder()
                 // For safety, this is a black hole IP: see RFC 6666
                 .baseUrl("http://[100:0:0:0:0:0:0:0]/")


### PR DESCRIPTION
* Where possible make instance fields final
* Remove unnecessary throws declarations
* Remove redundant warning suppression comment in KVCacheITest