### PR TITLE
Misc cleanup

### DIFF
--- a/src/itest/java/com/orbitz/consul/SnapshotClientITest.java
+++ b/src/itest/java/com/orbitz/consul/SnapshotClientITest.java
@@ -1,14 +1,14 @@
 package com.orbitz.consul;
 
+import static com.orbitz.consul.Awaiting.awaitWith25MsPoll;
 import static com.orbitz.consul.TestUtils.randomUUIDString;
 import static org.assertj.core.api.Assertions.assertThat;
-import static com.orbitz.consul.Awaiting.awaitWith25MsPoll;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
+
 import com.orbitz.consul.async.Callback;
 import com.orbitz.consul.option.QueryOptions;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -85,7 +85,7 @@ class SnapshotClientITest extends BaseIntegrationTest {
     }
 
     private <T> Callback<T> createCallback(final CountDownLatch latch, final AtomicBoolean success) {
-        return new Callback<T>() {
+        return new Callback<>() {
             @Override
             public void onResponse(T index) {
                 success.set(true);

--- a/src/main/java/com/orbitz/consul/CatalogClient.java
+++ b/src/main/java/com/orbitz/consul/CatalogClient.java
@@ -55,8 +55,9 @@ public class CatalogClient extends BaseCacheableClient {
 
     /**
      * Get the list of datacenters with query options
-     * @param queryOptions
-     * @return
+     *
+     * @param queryOptions the query options to use
+     * @return a list of the datacenters
      */
     public List<String> getDatacenters(QueryOptions queryOptions) {
         return http.extract(api.getDatacenters(queryOptions.toHeaders()));
@@ -116,8 +117,7 @@ public class CatalogClient extends BaseCacheableClient {
      * <p/>
      * GET /v1/catalog/services?dc={datacenter}
      *
-     * @param callback     Callback implemented by callee to handle results.
-     * @return A {@link ConsulResponse} containing a map of service name to list of tags.
+     * @param callback Callback implemented by callee to handle results; the callback is provided a map of service name to list of tags.
      */
     public void getServices(ConsulResponseCallback<Map<String, List<String>>> callback) {
         getServices(QueryOptions.BLANK, callback);
@@ -142,8 +142,7 @@ public class CatalogClient extends BaseCacheableClient {
      * GET /v1/catalog/services?dc={datacenter}
      *
      * @param queryOptions The Query Options to use.
-     * @param callback     Callback implemented by callee to handle results.
-     * @return A {@link ConsulResponse} containing a map of service name to list of tags.
+     * @param callback     Callback implemented by callee to handle results, containing a map of service name to list of tags
      */
     public void getServices(QueryOptions queryOptions, ConsulResponseCallback<Map<String, List<String>>> callback) {
         http.extractConsulResponse(api.getServices(queryOptions.toQuery(),
@@ -180,9 +179,7 @@ public class CatalogClient extends BaseCacheableClient {
      * GET /v1/catalog/service/{service}?dc={datacenter}
      *
      * @param queryOptions The Query Options to use.
-     * @param callback     Callback implemented by callee to handle results.
-     * @return A {@link ConsulResponse} containing
-     * {@link CatalogService} objects.
+     * @param callback     Callback implemented by callee to handle results, containing a list of {@link CatalogService} objects
      */
     public void getService(String service, QueryOptions queryOptions, ConsulResponseCallback<List<CatalogService>> callback) {
         http.extractConsulResponse(api.getService(service, queryOptions.toQuery(),

--- a/src/main/java/com/orbitz/consul/EventClient.java
+++ b/src/main/java/com/orbitz/consul/EventClient.java
@@ -176,7 +176,7 @@ public class EventClient extends BaseClient {
     }
 
     private ConsulResponseCallback<List<Event>> createConsulResponseCallbackWrapper(EventResponseCallback callback) {
-        return new ConsulResponseCallback<List<Event>>() {
+        return new ConsulResponseCallback<>() {
             @Override
             public void onComplete(ConsulResponse<List<Event>> response) {
                 callback.onComplete(ImmutableEventResponse.of(response.getResponse(), response.getIndex()));

--- a/src/main/java/com/orbitz/consul/HealthClient.java
+++ b/src/main/java/com/orbitz/consul/HealthClient.java
@@ -149,9 +149,7 @@ public class HealthClient extends BaseCacheableClient {
      *
      * @param state        The state to query.
      * @param queryOptions The Query Options to use.
-     * @param callback     Callback implemented by callee to handle results.
-     * @return A {@link ConsulResponse} containing a list of
-     * {@link HealthCheck} objects.
+     * @param callback     Callback implemented by callee to handle results, containing a list of {@link HealthCheck} objects.
      */
     public void getChecksByState(State state, QueryOptions queryOptions,
                                  ConsulResponseCallback<List<HealthCheck>> callback) {

--- a/src/main/java/com/orbitz/consul/SnapshotClient.java
+++ b/src/main/java/com/orbitz/consul/SnapshotClient.java
@@ -54,7 +54,7 @@ public class SnapshotClient extends BaseClient {
      * @param callback callback called once the operation is over. It the save operation is successful, the X-Consul-Index is send.
      */
     public void save(File destinationFile, QueryOptions queryOptions, Callback<BigInteger> callback) {
-        http.extractConsulResponse(api.generateSnapshot(queryOptions.toQuery()), new ConsulResponseCallback<ResponseBody>() {
+        http.extractConsulResponse(api.generateSnapshot(queryOptions.toQuery()), new ConsulResponseCallback<>() {
             @Override
             public void onComplete(ConsulResponse<ResponseBody> consulResponse) {
                 // Note that response.body() and response.body().byteStream() should be closed.

--- a/src/main/java/com/orbitz/consul/model/ConsulResponse.java
+++ b/src/main/java/com/orbitz/consul/model/ConsulResponse.java
@@ -11,12 +11,14 @@ import java.util.Optional;
 
 public class ConsulResponse<T> {
 
-    public static interface CacheResponseInfo {
+    public interface CacheResponseInfo {
         /**
          * This value can be null if value is not in cache
-         * @return
+         *
+         * @return an Optional containing the age in seconds, or an empty Optional
          */
         Optional<Long> getAgeInSeconds();
+
         boolean isCacheHit();
     }
 
@@ -94,7 +96,7 @@ public class ConsulResponse<T> {
     }
 
     /**
-     * @see https://developer.hashicorp.com/consul/api-docs/features/caching#background-refresh-caching
+     * @see <a href="https://developer.hashicorp.com/consul/api-docs/features/caching#background-refresh-caching">Background Refresh Caching</a>
      */
     public Optional<CacheResponseInfo> getCacheReponseInfo(){
         return cacheResponseInfo;

--- a/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
+++ b/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
@@ -45,13 +45,13 @@ public class ConsistencyMode {
      * @param maxStaleInSeconds Optional duration for which data can be late
      *                          compared to Consul Server leader.
      * @return a not null ConsistencyMode
-     * @see https://developer.hashicorp.com/consul/api-docs/features/caching#simple-caching
+     * @see <a href="https://developer.hashicorp.com/consul/api-docs/features/caching#simple-caching">Simple Caching</a>
      */
     public static final ConsistencyMode createCachedConsistencyWithMaxAgeAndStale(final Optional<Long> maxAgeInSeconds,
             final Optional<Long> maxStaleInSeconds) {
         String maxAge = "";
         if (maxAgeInSeconds.isPresent()) {
-            final long v = maxAgeInSeconds.get().longValue();
+            final long v = maxAgeInSeconds.get();
             if (v < 0) {
                 throw new IllegalArgumentException("maxAgeInSeconds must greater or equal to 0");
             }
@@ -59,7 +59,7 @@ public class ConsistencyMode {
         }
 
         if (maxStaleInSeconds.isPresent()) {
-            final long v = maxStaleInSeconds.get().longValue();
+            final long v = maxStaleInSeconds.get();
             if (v < 0){
                 throw new IllegalArgumentException("maxStaleInSeconds must greater or equal to 0");
             }

--- a/src/main/java/com/orbitz/consul/util/Http.java
+++ b/src/main/java/com/orbitz/consul/util/Http.java
@@ -73,7 +73,7 @@ public class Http {
 
     @VisibleForTesting
     <T> retrofit2.Callback<T> createRetrofitCallback(ConsulResponseCallback<T> callback, Integer... okCodes) {
-        return new retrofit2.Callback<T>() {
+        return new retrofit2.Callback<>() {
             @Override
             public void onResponse(Call<T> call, Response<T> response) {
                 if (isSuccessful(response, okCodes)) {
@@ -100,7 +100,7 @@ public class Http {
     }
 
     private <T> ConsulResponseCallback<T> createConsulResponseCallbackWrapper(Callback<T> callback) {
-        return new ConsulResponseCallback<T>() {
+        return new ConsulResponseCallback<>() {
             @Override
             public void onComplete(ConsulResponse<T> consulResponse) {
                 callback.onResponse(consulResponse.getResponse());
@@ -122,7 +122,7 @@ public class Http {
 
         BigInteger index = isNull(indexHeaderValue) ? BigInteger.ZERO : new BigInteger(indexHeaderValue);
         long lastContact = isNull(lastContactHeaderValue) ? 0 : NumberUtils.toLong(lastContactHeaderValue);
-        boolean knownLeader = nonNull(knownLeaderHeaderValue) && Boolean.valueOf(knownLeaderHeaderValue);
+        boolean knownLeader = nonNull(knownLeaderHeaderValue) && Boolean.parseBoolean(knownLeaderHeaderValue);
         return new ConsulResponse<>(response.body(), lastContact, knownLeader, index,
                                     headers.get("X-Cache"), headers.get("Age"));
     }

--- a/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
@@ -123,12 +123,6 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
         this.blacklist.put(fromRequest(current), Instant.now());
     }
 
-    /**
-     * Reconstructs a HostAndPort instance from the request object
-     *
-     * @param request
-     * @return
-     */
     private HostAndPort fromRequest(Request request) {
         return HostAndPort.fromParts(request.url().host(), request.url().port());
     }

--- a/src/main/java/com/orbitz/consul/util/failover/strategy/ConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/ConsulFailoverStrategy.java
@@ -19,7 +19,7 @@ public interface ConsulFailoverStrategy {
      * @return An optional failover request. This may return an empty optional, signaling that the request should be aborted
      */
     @NonNull
-    public Optional<Request> computeNextStage(@NonNull Request previousRequest, @Nullable Response previousResponse);
+    Optional<Request> computeNextStage(@NonNull Request previousRequest, @Nullable Response previousResponse);
 
     /**
      * Determines if there is a viable candidate for the next request. This lets us short circuit the first attempted request
@@ -29,7 +29,7 @@ public interface ConsulFailoverStrategy {
      * @param current The current inflight request.
      * @return A boolean representing if there is another possible request candidate available.
      */
-    public boolean isRequestViable(@NonNull Request current);
+    boolean isRequestViable(@NonNull Request current);
 
     /**
      * Marks the specified request as a failed URL (in case of exceptions and other events that could cause
@@ -38,6 +38,6 @@ public interface ConsulFailoverStrategy {
      *
      * @param current The current request object representing a request that failed
      */
-    public void markRequestFailed(@NonNull Request current);
+    void markRequestFailed(@NonNull Request current);
 
 }

--- a/src/test/java/com/orbitz/consul/cache/AsyncCallbackConsumer.java
+++ b/src/test/java/com/orbitz/consul/cache/AsyncCallbackConsumer.java
@@ -19,9 +19,8 @@ public class AsyncCallbackConsumer implements ConsulCache.CallbackConsumer<Value
     @Override
     public void consume(BigInteger index, final ConsulResponseCallback<List<Value>> callback) {
         callCount++;
-        thread = new Thread(() -> {
-            callback.onComplete(new ConsulResponse<List<Value>>(result, 0, true, BigInteger.ZERO, null, null));
-        });
+        thread = new Thread(() ->
+                callback.onComplete(new ConsulResponse<>(result, 0, true, BigInteger.ZERO, null, null)));
         thread.setName("asyncCallbackConsumer");
 
         thread.start();

--- a/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
+++ b/src/test/java/com/orbitz/consul/cache/ConsulCacheTest.java
@@ -313,7 +313,7 @@ class ConsulCacheTest {
         List<Value> result = List.of(value);
 
         try (var callbackConsumer = new AsyncCallbackConsumer(result)) {
-            try (var cache = new ConsulCache<String, Value>(
+            try (var cache = new ConsulCache<>(
                     keyExtractor, callbackConsumer, cacheConfig, eventHandler, new CacheDescriptor(""))) {
 
                 var goodListener = new StubListener();
@@ -356,7 +356,7 @@ class ConsulCacheTest {
         List<Value> result = List.of(value);
         var callbackConsumer = new StubCallbackConsumer(result);
 
-        try (var cache = new ConsulCache<String, Value>(
+        try (var cache = new ConsulCache<>(
                 keyExtractor, callbackConsumer, cacheConfig, eventHandler, new CacheDescriptor(""))) {
 
             var badListener = new AlwaysThrowsListener();


### PR DESCRIPTION
* Javadoc cleanup
* Use diamond operator instead of redundant type parameter
* Interface members are public by default
* Inner interfaces are static by default
* Remove unnecessary unboxing
* Use lambda expressions