### PR TITLE
Fix nullability issues by adding null/not-null annotations

### DIFF
--- a/src/main/java/com/orbitz/consul/cache/TimeoutInterceptor.java
+++ b/src/main/java/com/orbitz/consul/cache/TimeoutInterceptor.java
@@ -9,6 +9,7 @@ import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,6 +27,7 @@ public class TimeoutInterceptor implements Interceptor {
         this.config = config;
     }
 
+    @NotNull
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();
@@ -34,8 +36,7 @@ public class TimeoutInterceptor implements Interceptor {
         // Snapshot might be very large. Timeout should be adjusted for this endpoint.
         if (request.url().encodedPath().contains("snapshot")) {
             readTimeout = (int) Duration.ofHours(1).toMillis();
-        }
-        else if (config.isTimeoutAutoAdjustmentEnabled()) {
+        } else if (config.isTimeoutAutoAdjustmentEnabled()) {
             String waitQuery = request.url().queryParameter("wait");
             Duration waitDuration = parseWaitQuery(waitQuery);
             if (nonNull(waitDuration)) {
@@ -44,7 +45,7 @@ public class TimeoutInterceptor implements Interceptor {
 
                 // According to https://developer.hashicorp.com/consul/api-docs/features/blocking
                 // A small random amount of additional wait time is added to the supplied maximum wait time by consul
-                // agent to spread out the wake up time of any concurrent requests.
+                // agent to spread out the wake-up time of any concurrent requests.
                 // This adds up to (wait / 16) additional time to the maximum duration.
                 int readTimeoutRequiredMargin = (int) Math.ceil((double)(waitDurationMs) / 16);
 

--- a/src/main/java/com/orbitz/consul/util/Http.java
+++ b/src/main/java/com/orbitz/consul/util/Http.java
@@ -12,6 +12,7 @@ import com.orbitz.consul.model.ConsulResponse;
 import com.orbitz.consul.monitoring.ClientEventHandler;
 import okhttp3.Headers;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import retrofit2.Call;
 import retrofit2.Response;
 
@@ -75,7 +76,7 @@ public class Http {
     <T> retrofit2.Callback<T> createRetrofitCallback(ConsulResponseCallback<T> callback, Integer... okCodes) {
         return new retrofit2.Callback<>() {
             @Override
-            public void onResponse(Call<T> call, Response<T> response) {
+            public void onResponse(@NonNull Call<T> call, @NonNull Response<T> response) {
                 if (isSuccessful(response, okCodes)) {
                     eventHandler.httpRequestSuccess(call.request());
                     callback.onComplete(consulResponse(response));
@@ -87,7 +88,7 @@ public class Http {
             }
 
             @Override
-            public void onFailure(Call<T> call, Throwable t) {
+            public void onFailure(@NonNull Call<T> call, @NonNull Throwable t) {
                 eventHandler.httpRequestFailure(call.request(), t);
                 callback.onFailure(t);
             }

--- a/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendInterceptor.java
+++ b/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendInterceptor.java
@@ -3,6 +3,7 @@ package com.orbitz.consul.util.bookend;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
@@ -14,6 +15,7 @@ public class ConsulBookendInterceptor implements Interceptor {
         this.consulBookend = consulBookend;
     }
 
+    @NotNull
     @Override
     public Response intercept(Chain chain) throws IOException {
         Request request = chain.request();

--- a/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
+++ b/src/main/java/com/orbitz/consul/util/failover/ConsulFailoverInterceptor.java
@@ -7,6 +7,7 @@ import com.orbitz.consul.util.failover.strategy.ConsulFailoverStrategy;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,6 +39,7 @@ public class ConsulFailoverInterceptor implements Interceptor {
         this.strategy = strategy;
     }
 
+    @NotNull
     @Override
     public Response intercept(Chain chain) {
 

--- a/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
+++ b/src/main/java/com/orbitz/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
@@ -6,6 +6,8 @@ import com.google.common.net.HostAndPort;
 import okhttp3.HttpUrl;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -39,8 +41,9 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
         this.timeout = timeout;
     }
 
+    @NonNull
     @Override
-    public Optional<Request> computeNextStage(Request previousRequest, Response previousResponse) {
+    public Optional<Request> computeNextStage(@NonNull Request previousRequest, @Nullable Response previousResponse) {
 
         // Create a host and port
         final HostAndPort initialTarget = fromRequest(previousRequest);
@@ -67,7 +70,7 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
             final HttpUrl nextURL = previousRequest.url().newBuilder().host(next.getHost()).port(next.getPort()).build();
 
             // Return the result
-            return Optional.ofNullable(previousRequest.newBuilder().url(nextURL).build());
+            return Optional.of(previousRequest.newBuilder().url(nextURL).build());
         } else {
 
             // Construct the next URL using the old parameters (ensures we don't have to do
@@ -75,7 +78,7 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
             final HttpUrl nextURL = previousRequest.url().newBuilder().host(initialTarget.getHost()).port(initialTarget.getPort()).build();
 
             // Return the result
-            return Optional.ofNullable(previousRequest.newBuilder().url(nextURL).build());
+            return Optional.of(previousRequest.newBuilder().url(nextURL).build());
         }
 
     }
@@ -114,12 +117,12 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
     }
 
     @Override
-    public boolean isRequestViable(Request current) {
+    public boolean isRequestViable(@NonNull Request current) {
         return (targets.size() > blacklist.size()) || !blacklist.containsKey(fromRequest(current));
     }
 
     @Override
-    public void markRequestFailed(Request current) {
+    public void markRequestFailed(@NonNull Request current) {
         this.blacklist.put(fromRequest(current), Instant.now());
     }
 

--- a/src/test/java/com/orbitz/consul/cache/TimeoutInterceptorTest.java
+++ b/src/test/java/com/orbitz/consul/cache/TimeoutInterceptorTest.java
@@ -9,7 +9,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.orbitz.consul.config.CacheConfig;
-
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -23,15 +25,13 @@ import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import okhttp3.Interceptor;
-import okhttp3.Request;
-
 class TimeoutInterceptorTest {
 
     @ParameterizedTest(name = "expected timeout of {4} ms for url {0} with timeout of {1} ms and margin of {3} ms (enabled: {2})")
     @MethodSource("getInterceptParameters")
     void checkIntercept(String url, int defaultTimeout, boolean enabled, int margin, int expectedTimeoutMs)
             throws IOException {
+
         CacheConfig config = createConfigMock(enabled, margin);
         Interceptor.Chain chain = createChainMock(defaultTimeout, url);
 
@@ -75,7 +75,9 @@ class TimeoutInterceptorTest {
         when(chain.request()).thenReturn(request);
         when(chain.readTimeoutMillis()).thenReturn(defaultTimeout);
         when(chain.withReadTimeout(anyInt(), any(TimeUnit.class))).thenReturn(chain);
-        when(chain.proceed(any(Request.class))).thenReturn(null);
+
+        var response = mock(Response.class);
+        when(chain.proceed(any(Request.class))).thenReturn(response);
 
         return chain;
     }


### PR DESCRIPTION
* Add NotNull annotation to TimeoutInterceptor. I used the Jetbrains one because the Checker one didn't satisfy IntelliJ, and the okhttp kotlin dependencies already bring in the Jetbrains annotations, so we're not adding another dependency.
* Fix TimeoutInterceptorTest after adding NotNull because it (somehow) started failing the tests because a method annotated with NotNull was returning null. Pretty nice...need to investigate what caught that.
* Add Checker NonNull and Nullable annotations to the other classes both to return values and parameters
* Last, use Optional#of instead of Optional#ofNullable where the value is known to be non-null