### PR TITLE
Misc test cleanup

### DIFF
--- a/src/itest/java/com/orbitz/consul/ReadmeExamplesTest.java
+++ b/src/itest/java/com/orbitz/consul/ReadmeExamplesTest.java
@@ -1,6 +1,7 @@
 package com.orbitz.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
+
 import com.orbitz.consul.cache.KVCache;
 import com.orbitz.consul.cache.ServiceHealthCache;
 import com.orbitz.consul.cache.ServiceHealthKey;
@@ -8,7 +9,6 @@ import com.orbitz.consul.model.agent.ImmutableRegistration;
 import com.orbitz.consul.model.agent.Registration;
 import com.orbitz.consul.model.health.ServiceHealth;
 import com.orbitz.consul.model.kv.Value;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -66,7 +66,7 @@ class ReadmeExamplesTest extends BaseIntegrationTest {
         KeyValueClient kvClient = client.keyValueClient();
 
         kvClient.putValue("foo", "bar");
-        String value = kvClient.getValueAsString("foo").get(); // bar
+        String value = kvClient.getValueAsString("foo").orElseThrow(); // bar
 
         assertThat(value).isEqualTo("bar");
     }
@@ -88,7 +88,7 @@ class ReadmeExamplesTest extends BaseIntegrationTest {
             newValue.ifPresent(value -> {
                 // Values are encoded in key/value store, decode it if needed
                 Optional<String> decodedValue = newValue.get().getValueAsString();
-                decodedValue.ifPresent(v -> System.out.println(String.format("Value is: %s", v))); //prints "bar"
+                decodedValue.ifPresent(v -> System.out.printf("Value is: %s%n", v)); // prints "bar"
             });
         });
         cache.start();

--- a/src/itest/java/com/orbitz/consul/SnapshotClientITest.java
+++ b/src/itest/java/com/orbitz/consul/SnapshotClientITest.java
@@ -9,14 +9,15 @@ import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
 
 import com.orbitz.consul.async.Callback;
 import com.orbitz.consul.option.QueryOptions;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -29,14 +30,9 @@ class SnapshotClientITest extends BaseIntegrationTest {
     private SnapshotClient snapshotClient;
 
     @BeforeEach
-    void setUp() throws IOException {
+    void setUp(@TempDir Path tempDir) throws IOException {
         snapshotClient = client.snapshotClient();
-        snapshotFile = File.createTempFile("snapshot", ".gz");
-    }
-
-    @AfterEach
-    void tearDown() {
-        snapshotFile.delete();
+        snapshotFile = File.createTempFile("snapshot", ".gz", tempDir.toFile());
     }
 
     @Test

--- a/src/itest/java/com/orbitz/consul/StatusClientITest.java
+++ b/src/itest/java/com/orbitz/consul/StatusClientITest.java
@@ -36,9 +36,7 @@ class StatusClientITest extends BaseIntegrationTest {
         try {
             netInts = NetworkInterface.getNetworkInterfaces();
             for (NetworkInterface netInt : Collections.list(netInts)) {
-                for (InetAddress inetAddress : Collections.list(netInt.getInetAddresses())) {
-                    ips.add(inetAddress);
-                }
+                ips.addAll(Collections.list(netInt.getInetAddresses()));
             }
         } catch (SocketException ex) {
             LOG.warn("Could not access local network adapters. Continuing", ex);

--- a/src/itest/java/com/orbitz/consul/cache/HealthCheckCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/HealthCheckCacheITest.java
@@ -4,11 +4,11 @@ import static com.orbitz.consul.Awaiting.awaitAtMost500ms;
 import static com.orbitz.consul.TestUtils.randomUUIDString;
 import static java.util.Objects.isNull;
 import static org.assertj.core.api.Assertions.assertThat;
+
 import com.orbitz.consul.AgentClient;
 import com.orbitz.consul.BaseIntegrationTest;
 import com.orbitz.consul.model.State;
 import com.orbitz.consul.model.health.HealthCheck;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -39,6 +39,7 @@ class HealthCheckCacheITest extends BaseIntegrationTest {
                 hCheck.awaitInitialized(3, TimeUnit.SECONDS);
 
                 HealthCheck check = hCheck.getMap().get(checkId);
+                assertThat(check).isNotNull();
                 assertThat(check.getCheckId()).isEqualTo(checkId);
 
                 agentClient.failCheck(checkId);

--- a/src/itest/java/com/orbitz/consul/cache/KVCacheITest.java
+++ b/src/itest/java/com/orbitz/consul/cache/KVCacheITest.java
@@ -268,7 +268,7 @@ class KVCacheITest extends BaseIntegrationTest {
     }
 
     @Test
-    void ensureCacheInitialization() {
+    void ensureCacheInitialization() throws InterruptedException {
         var key = randomUUIDString();
         var value = randomUUIDString();
         kvClient.putValue(key, value);
@@ -283,9 +283,8 @@ class KVCacheITest extends BaseIntegrationTest {
             });
 
             cache.start();
-            completed.await(2, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            fail("", e.getMessage());
+            var countReachedZero = completed.await(2, TimeUnit.SECONDS);
+            assertThat(countReachedZero).isTrue();
         } finally {
             kvClient.deleteKey(key);
         }
@@ -295,7 +294,7 @@ class KVCacheITest extends BaseIntegrationTest {
 
     @ParameterizedTest(name = "queries of {0} seconds")
     @MethodSource("getBlockingQueriesDuration")
-    void checkUpdateNotifications(int queryDurationSec) {
+    void checkUpdateNotifications(int queryDurationSec) throws InterruptedException {
         var scheduledExecutor = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setDaemon(true).setNameFormat("kvcache-itest-%d").build()
         );
@@ -316,9 +315,8 @@ class KVCacheITest extends BaseIntegrationTest {
 
             cache.start();
             scheduledExecutor.schedule(() -> kvClient.putValue(key, newValue), 3, TimeUnit.SECONDS);
-            completed.await(4, TimeUnit.SECONDS);
-        } catch (Exception e) {
-            fail(e.getMessage(), e);
+            var countReachedZero = completed.await(4, TimeUnit.SECONDS);
+            assertThat(countReachedZero).isTrue();
         } finally {
             kvClient.deleteKey(key);
             scheduledExecutor.shutdownNow();


### PR DESCRIPTION
* Add a not-null assertion in cacheShouldContainPassingTestsOnly in HealthCheckCacheITest to ensure the subsequent check cannot fail with a NPE
* Remove "catch Exception" in KVCacheITest and just use a "throws" declaration instead; IntelliJ was complaining that certain types of JVM (Runtime) exceptions would be accidentally ignored, though in reality it just makes the test a little clearer to allow the InterruptedExceptions to propagate instead of catching all exceptions and calling AssertJ's fail method
* Update the ReadmeExamplesTest with cleaner code
* Use a JUnit Jupiter TempDir in SnapshotClientITest instead of manually cleaning up the file (and ignoring whether it was actually deleted)
* Use Collection#addAll in StatusClientITest instead of a for loop and calling add in each iteration
* Add additional assertions to the CountDownLatches in HttpTest, and add static imports for the AssertJ Assertions class