### PR TITLE
Clean up problems found by IntelliJ's code inspections

### DIFF
--- a/src/main/java/com/orbitz/consul/model/ConsulResponse.java
+++ b/src/main/java/com/orbitz/consul/model/ConsulResponse.java
@@ -59,7 +59,7 @@ public class ConsulResponse<T> {
     private final Optional<CacheResponseInfo> cacheResponseInfo;
 
     @VisibleForTesting
-    static CacheResponseInfo buildCacheReponseInfo(String headerHitMiss, String headerAge) throws NumberFormatException {
+    static CacheResponseInfo buildCacheResponseInfo(String headerHitMiss, String headerAge) throws NumberFormatException {
         ConsulResponse.CacheResponseInfo cacheInfo = null;
         if (nonNull(headerHitMiss)) {
             cacheInfo = new CacheResponseInfoImpl(headerHitMiss, headerAge);
@@ -68,7 +68,7 @@ public class ConsulResponse<T> {
     }
 
     public ConsulResponse(T response, long lastContact, boolean knownLeader, BigInteger index, String headerHitMiss, String headerAge) throws NumberFormatException {
-        this(response, lastContact, knownLeader, index, Optional.ofNullable(buildCacheReponseInfo(headerHitMiss, headerAge)));
+        this(response, lastContact, knownLeader, index, Optional.ofNullable(buildCacheResponseInfo(headerHitMiss, headerAge)));
     }
 
     public ConsulResponse(T response, long lastContact, boolean knownLeader, BigInteger index, Optional<CacheResponseInfo> cacheInfo) {

--- a/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
+++ b/src/main/java/com/orbitz/consul/option/ConsistencyMode.java
@@ -13,11 +13,11 @@ public class ConsistencyMode {
     private final String param;
     private final Map<String, String> additionalHeaders;
 
-    private ConsistencyMode(final String name, int ordinal, final String param) {
+    private ConsistencyMode(String name, int ordinal, String param) {
         this(name, ordinal, param, Map.of());
     }
 
-    private ConsistencyMode(final String name, int ordinal, final String param, final Map<String, String> headers) {
+    private ConsistencyMode(String name, int ordinal, String param, Map<String, String> headers) {
         this.name = name;
         this.ordinal = ordinal;
         this.param = param;
@@ -47,11 +47,11 @@ public class ConsistencyMode {
      * @return a not null ConsistencyMode
      * @see <a href="https://developer.hashicorp.com/consul/api-docs/features/caching#simple-caching">Simple Caching</a>
      */
-    public static final ConsistencyMode createCachedConsistencyWithMaxAgeAndStale(final Optional<Long> maxAgeInSeconds,
-            final Optional<Long> maxStaleInSeconds) {
+    public static ConsistencyMode createCachedConsistencyWithMaxAgeAndStale(Optional<Long> maxAgeInSeconds,
+                                                                            Optional<Long> maxStaleInSeconds) {
         String maxAge = "";
         if (maxAgeInSeconds.isPresent()) {
-            final long v = maxAgeInSeconds.get();
+            long v = maxAgeInSeconds.get();
             if (v < 0) {
                 throw new IllegalArgumentException("maxAgeInSeconds must greater or equal to 0");
             }
@@ -59,7 +59,7 @@ public class ConsistencyMode {
         }
 
         if (maxStaleInSeconds.isPresent()) {
-            final long v = maxStaleInSeconds.get();
+            long v = maxStaleInSeconds.get();
             if (v < 0){
                 throw new IllegalArgumentException("maxStaleInSeconds must greater or equal to 0");
             }
@@ -78,11 +78,13 @@ public class ConsistencyMode {
     }
 
     // The next methods are for compatibility with old enum type
+
     /**
      * ConsistencyMode used t be an enum, implement it.
+     *
      * @return the old enum name
      */
-    public final String name(){
+    public final String name() {
         return name;
     }
 
@@ -96,12 +98,12 @@ public class ConsistencyMode {
         return builder.toString();
     }
 
-    public int ordinal(){
+    public int ordinal() {
         return ordinal;
     }
 
-    public static final ConsistencyMode[] values(){
-        ConsistencyMode[] res = new ConsistencyMode[3];
+    public static ConsistencyMode[] values() {
+        var res = new ConsistencyMode[3];
         res[0] = DEFAULT;
         res[1] = STALE;
         res[2] = CONSISTENT;

--- a/src/main/java/com/orbitz/consul/option/QueryOptions.java
+++ b/src/main/java/com/orbitz/consul/option/QueryOptions.java
@@ -1,5 +1,9 @@
 package com.orbitz.consul.option;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.orbitz.consul.option.Options.optionallyAdd;
+import static java.util.Objects.isNull;
+
 import org.immutables.value.Value;
 
 import java.math.BigInteger;
@@ -7,10 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.orbitz.consul.option.Options.optionallyAdd;
-import static java.util.Objects.isNull;
 
 /**
  * Container for common query options used by the Consul API.
@@ -106,9 +106,7 @@ public abstract class QueryOptions implements ParamAdder {
         Map<String, Object> result = new HashMap<>();
 
         Optional<String> consistency = getConsistencyMode().toParam();
-        if (consistency.isPresent()) {
-            result.put(consistency.get(), "");
-        }
+        consistency.ifPresent(s -> result.put(s, ""));
 
         if (isBlocking()) {
             optionallyAdd(result, "wait", getWait());

--- a/src/main/java/com/orbitz/consul/option/TransactionOptions.java
+++ b/src/main/java/com/orbitz/consul/option/TransactionOptions.java
@@ -1,12 +1,12 @@
 package com.orbitz.consul.option;
 
-import java.util.Optional;
+import static com.orbitz.consul.option.Options.optionallyAdd;
+
 import org.immutables.value.Value;
 
 import java.util.HashMap;
 import java.util.Map;
-
-import static com.orbitz.consul.option.Options.optionallyAdd;
+import java.util.Optional;
 
 /**
  * Container for common transaction options used by the Consul API.
@@ -37,10 +37,7 @@ public abstract class TransactionOptions implements ParamAdder {
 
     @Override
     public Map<String, String> toHeaders() {
-        Map<String, String> result = new HashMap<>();
-
-        ConsistencyMode consistencyMode = getConsistencyMode();
-        result.putAll(consistencyMode.getAdditionalHeaders());
-        return result;
+        var consistencyMode = getConsistencyMode();
+        return new HashMap<>(consistencyMode.getAdditionalHeaders());
     }
 }

--- a/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendContext.java
+++ b/src/main/java/com/orbitz/consul/util/bookend/ConsulBookendContext.java
@@ -1,12 +1,11 @@
 package com.orbitz.consul.util.bookend;
 
-import java.util.Optional;
-
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.isNull;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 public class ConsulBookendContext {
 
@@ -38,6 +37,6 @@ public class ConsulBookendContext {
                 "Data for key '%s' is not of type: %s", key, klazz.getName());
 
         T castObject = klazz.cast(object);
-        return Optional.ofNullable(castObject);
+        return Optional.of(castObject);
     }
 }


### PR DESCRIPTION
* ConsulCache: use isEmpty instead of !isPresent
* ConsulResponse: rename buildCacheReponseInfo to buildCacheResponseInfo
* ConsistencyMode: remove final modifiers from method arguments and local vars to de-clutter the code, remove meaningless final modifier from several methods; add space between ending parentheses and opening curly brace on several methods
* QueryOptions: Use functional style (replace isPresent + get with ifPresent)
* TransactionOptions: Use HashMap constructor instead of calling putAll
* ConsulBookendContext: Fix another nullability problem: replace Optional#ofNullable with Optional#of since the object is known to be not-null