### PR TITLE
Configure Shade plugin not to create a dependency reduced pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -238,6 +238,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>shaded</shadedClassifierName>
                             <transformers>


### PR DESCRIPTION
* Set createDependencyReducedPom to false in shade plugin configuration

The one possible downside here is that the resulting POM in the uber-jar (i.e. deep in its META-INf directory) is the regular POM which includes dependencies that are actually shaded, and thus not needed by the uber-jar.

Fixes #214