### PR TITLE
Update Docker image name for Consul to hashicorp/consul:1.15

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/AclClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/AclClientITest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
+import static org.kiwiproject.consul.ConsulTestcontainers.CONSUL_DOCKER_IMAGE_NAME;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
 
 import com.google.common.net.HostAndPort;
@@ -29,7 +30,7 @@ class AclClientITest {
 
     static {
         // noinspection resource
-        consulContainerAcl = new GenericContainer<>("consul")
+        consulContainerAcl = new GenericContainer<>(CONSUL_DOCKER_IMAGE_NAME)
                 .withCommand("agent", "-dev", "-client", "0.0.0.0", "--enable-script-checks=true")
                 .withExposedPorts(8500)
                 .withEnv("CONSUL_LOCAL_CONFIG",

--- a/src/itest/java/org/kiwiproject/consul/BaseIntegrationTest.java
+++ b/src/itest/java/org/kiwiproject/consul/BaseIntegrationTest.java
@@ -1,5 +1,6 @@
 package org.kiwiproject.consul;
 
+import static org.kiwiproject.consul.ConsulTestcontainers.CONSUL_DOCKER_IMAGE_NAME;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
 
 import com.google.common.net.HostAndPort;
@@ -27,7 +28,7 @@ public abstract class BaseIntegrationTest {
 
     static {
         // noinspection resource
-        consulContainer = new GenericContainer<>("consul")
+        consulContainer = new GenericContainer<>(CONSUL_DOCKER_IMAGE_NAME)
                 .withCommand("agent", "-dev", "-client", "0.0.0.0", "--enable-script-checks=true")
                 .withExposedPorts(8500);
         consulContainer.start();
@@ -37,17 +38,17 @@ public abstract class BaseIntegrationTest {
 
     static {
         // noinspection resource
-        consulContainerAcl = new GenericContainer<>("consul")
+        consulContainerAcl = new GenericContainer<>(CONSUL_DOCKER_IMAGE_NAME)
                 .withCommand("agent", "-dev", "-client", "0.0.0.0", "--enable-script-checks=true")
                 .withExposedPorts(8500)
                 .withEnv("CONSUL_LOCAL_CONFIG",
                         "{\n" +
                                 "  \"acl\": {\n" +
                                 "    \"enabled\": true,\n" +
-                    "    \"default_policy\": \"deny\",\n" +
-                    "    \"tokens\": {\n" +
-                    "      \"master\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"\n" +
-                    "    }\n" +
+                                "    \"default_policy\": \"deny\",\n" +
+                                "    \"tokens\": {\n" +
+                                "      \"master\": \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"\n" +
+                                "    }\n" +
                     "  }\n" +
                     "}"
             );

--- a/src/itest/java/org/kiwiproject/consul/ConsulTestcontainers.java
+++ b/src/itest/java/org/kiwiproject/consul/ConsulTestcontainers.java
@@ -1,0 +1,10 @@
+package org.kiwiproject.consul;
+
+public class ConsulTestcontainers {
+
+    private ConsulTestcontainers() {
+        // utility class
+    }
+
+    public static final String CONSUL_DOCKER_IMAGE_NAME = "hashicorp/consul:1.15";
+}

--- a/src/itest/java/org/kiwiproject/consul/SnapshotClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/SnapshotClientITest.java
@@ -2,8 +2,8 @@ package org.kiwiproject.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
 import static org.awaitility.Durations.FIVE_SECONDS;
-import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
 import static org.kiwiproject.consul.Awaiting.awaitWith25MsPoll;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
 
@@ -47,12 +47,12 @@ class SnapshotClientITest extends BaseIntegrationTest {
 
         client.agentClient().register(8080, new URL("http://localhost:123/health"), 1000L, serviceName, serviceId,
                 List.of(), Map.of());
-        awaitWith25MsPoll().atMost(TWO_HUNDRED_MILLISECONDS).until(() -> serviceExists(serviceName));
+        awaitWith25MsPoll().atMost(FIVE_HUNDRED_MILLISECONDS).until(() -> serviceExists(serviceName));
 
         ensureSaveSnapshot();
 
         client.agentClient().deregister(serviceId);
-        awaitWith25MsPoll().atMost(TWO_HUNDRED_MILLISECONDS).until(() -> !serviceExists(serviceName));
+        awaitWith25MsPoll().atMost(FIVE_HUNDRED_MILLISECONDS).until(() -> !serviceExists(serviceName));
 
         ensureRestoreSnapshot();
 


### PR DESCRIPTION
This is because of the notice posted to hub.docker.com:

Upcoming in Consul 1.16, we will stop publishing official Dockerhub images and publish only our Verified Publisher images. Users of Docker images should pull from hashicorp/consul instead of consul. Verified Publisher images can be found at
https://hub.docker.com/r/hashicorp/consul.