### PR TITLE
Ignore RefreshErrorLogConsumer type during JSON serialization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
         </dependency>
 

--- a/src/main/java/org/kiwiproject/consul/config/CacheConfig.java
+++ b/src/main/java/org/kiwiproject/consul/config/CacheConfig.java
@@ -3,6 +3,7 @@ package org.kiwiproject.consul.config;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreType;
 import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 
@@ -285,6 +286,7 @@ public class CacheConfig {
         }
     }
 
+    @JsonIgnoreType
     public interface RefreshErrorLogConsumer {
         void accept(Logger logger, String message, Throwable error);
     }


### PR DESCRIPTION
* Add JsonIgnoreType annotation to the RefreshErrorLogConsumer interface inside CacheConfig so that any property of this type will be ignored when serializing CacheConfig to JSON
* Add jackson-datatype-jsr310 as a compile-scope dependency, so that attempts to serialize CacheConfig to JSON work as expected. Without this dependency, Jackson throws an exception since the JavaTimeModule isn't registered, and it doesn't know how to serialize Duration objects to JSON
* Add tests to CacheConfig to verify JSON serialization behavior for CacheConfig objects, as well as classes that contain properties of type RefreshErrorLogConsumer. The expected behavior is that RefreshErrorLogConsumer types are never serialized to JSON.

Closes #245