### PR TITLE
Change Jackson JSR310 dependency to test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -139,11 +139,6 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-jsr310</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-guava</artifactId>
         </dependency>
 
@@ -170,6 +165,12 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/org/kiwiproject/consul/config/CacheConfigTest.java
+++ b/src/test/java/org/kiwiproject/consul/config/CacheConfigTest.java
@@ -40,6 +40,10 @@ import java.util.stream.Stream;
 
 class CacheConfigTest {
 
+    /**
+     * @implNote To serialize CacheConfig to JSON, we need to register the JavaTimeModule so that classes
+     * in the java.time package (e.g. Duration) can be serialized.
+     */
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
 
     @Test


### PR DESCRIPTION
Since CacheConfig won't normally be serialized to
JSON, change the Jackson JSR310 (JavaTimeModule)
dependency to be test-scoped in the POM.