### PR TITLE
Remove dead/unreachable code from QueryOptions

### DIFF
--- a/src/main/java/org/kiwiproject/consul/option/QueryOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/QueryOptions.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.consul.option;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.isNull;
 
 import org.immutables.value.Value;
 
@@ -52,16 +51,12 @@ public abstract class QueryOptions implements ParamAdder {
 
     @Value.Derived
     public List<String> getNodeMetaQuery() {
-        return isNull(getNodeMeta())
-                ? List.of()
-                : List.copyOf(getNodeMeta());
+        return List.copyOf(getNodeMeta());
     }
 
     @Value.Derived
     public List<String> getTagsQuery() {
-        return isNull(getTag())
-                ? List.of()
-                : List.copyOf(getTag());
+        return List.copyOf(getTag());
     }
 
     @Value.Check


### PR DESCRIPTION
The null checks in QueryOptions#getNodeMetaQuery and #getTagsQuery are unreachable because you cannot construct a QueryOptions instance (ImmutableQueryOptions) that contains null nodeMeta or tag values. Therefore, there is no way in the #getNodeMetaQuery and #getTagsQuery methods for the null checks to succeed, which implies the code in the ternary expression is unreachable.

Closes #151