### PR TITLE
Deprecate TokenType for removal

### DIFF
--- a/src/main/java/org/kiwiproject/consul/model/acl/TokenType.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/TokenType.java
@@ -1,5 +1,10 @@
 package org.kiwiproject.consul.model.acl;
 
+/**
+ * @deprecated for removal without replacement, since this was part of the legacy ACL system. For more details see
+ * comments in <a href="https://github.com/kiwiproject/consul-client/issues/185">Investigate: TokenType enum is not used</a>
+ */
+@Deprecated(since = "1.1.0", forRemoval = true)
 public enum TokenType {
 
     CLIENT("client"), MANAGEMENT("management");


### PR DESCRIPTION
It is deprecated since 1.1.0, and will be removed in a future major version since it changes the public API (even with it being unused, we should follow correct SemVer semantics)

Closes #257