### PR TITLE
Use okio-bom in dependency management to control the version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <!-- Versions for required dependencies -->
         <immutables.version>2.9.3</immutables.version>
         <kiwi-bom.version>2.0.0</kiwi-bom.version>
+        <okio.version>3.5.0</okio.version>
         <retrofit.version>2.9.0</retrofit.version>
 
         <!-- Versions for test dependencies -->
@@ -75,6 +76,14 @@
                 <groupId>org.kiwiproject</groupId>
                 <artifactId>kiwi-bom</artifactId>
                 <version>${kiwi-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-bom</artifactId>
+                <version>${okio.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
* Add okio-bom with version 3.5.0 to dependency management
* This fixes a CVE from 3.2.0 related to a type conversion error; see https://github.com/square/okio/pull/1280