### PR TITLE
Use new Immutables Jakarta style to generate jakarta annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,11 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+
         <!-- Test dependencies -->
 
         <dependency>

--- a/src/main/java/org/kiwiproject/consul/cache/ServiceHealthKey.java
+++ b/src/main/java/org/kiwiproject/consul/cache/ServiceHealthKey.java
@@ -8,6 +8,7 @@ import org.kiwiproject.consul.model.health.ServiceHealth;
  * Provides a unique key for a {@link ServiceHealth} entry in a {@link ServiceHealthCache}
  */
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class ServiceHealthKey {
 

--- a/src/main/java/org/kiwiproject/consul/model/EventResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/EventResponse.java
@@ -9,6 +9,7 @@ import java.math.BigInteger;
 import java.util.List;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableEventResponse.class)
 @JsonDeserialize(as = ImmutableEventResponse.class)
 public abstract class EventResponse {

--- a/src/main/java/org/kiwiproject/consul/model/acl/AclResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/AclResponse.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableAclResponse.class)
 @JsonDeserialize(as = ImmutableAclResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/AclToken.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/AclToken.java
@@ -9,6 +9,7 @@ import org.immutables.value.Value;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableAclToken.class)
 @JsonDeserialize(as = ImmutableAclToken.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/AclTokenId.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/AclTokenId.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableAclTokenId.class)
 @JsonDeserialize(as = ImmutableAclTokenId.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/Policy.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/Policy.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutablePolicy.class)
 @JsonDeserialize(as = ImmutablePolicy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/PolicyListResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/PolicyListResponse.java
@@ -7,6 +7,7 @@ import org.immutables.value.Value;
 
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutablePolicyListResponse.class)
 @JsonDeserialize(as = ImmutablePolicyListResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/PolicyResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/PolicyResponse.java
@@ -7,6 +7,7 @@ import org.immutables.value.Value;
 
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutablePolicyResponse.class)
 @JsonDeserialize(as = ImmutablePolicyResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/Role.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/Role.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableRole.class)
 @JsonDeserialize(as = ImmutableRole.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/RoleListResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/RoleListResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableRoleListResponse.class)
 @JsonDeserialize(as = ImmutableRoleListResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/RoleResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/RoleResponse.java
@@ -7,6 +7,7 @@ import org.immutables.value.Value;
 
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableRoleResponse.class)
 @JsonDeserialize(as = ImmutableRoleResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/Token.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/Token.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableToken.class)
 @JsonDeserialize(as = ImmutableToken.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/TokenListResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/TokenListResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableTokenListResponse.class)
 @JsonDeserialize(as = ImmutableTokenListResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/acl/TokenResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/acl/TokenResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableTokenResponse.class)
 @JsonDeserialize(as = ImmutableTokenResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/agent/Agent.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/Agent.java
@@ -10,6 +10,7 @@ import org.immutables.value.Value;
 import java.util.Map;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSerialize(as = ImmutableAgent.class)
 @JsonDeserialize(as = ImmutableAgent.class)

--- a/src/main/java/org/kiwiproject/consul/model/agent/Check.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/Check.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSerialize(as = ImmutableCheck.class)
 @JsonDeserialize(as = ImmutableCheck.class)

--- a/src/main/java/org/kiwiproject/consul/model/agent/Config.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/Config.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableConfig.class)
 @JsonDeserialize(as = ImmutableConfig.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/agent/FullService.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/FullService.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableFullService.class)
 @JsonDeserialize(as = ImmutableFullService.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/agent/Member.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/Member.java
@@ -10,6 +10,7 @@ import org.immutables.value.Value;
 import java.util.Map;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableMember.class)
 @JsonDeserialize(as = ImmutableMember.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/agent/Ports.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/Ports.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutablePorts.class)
 @JsonDeserialize(as = ImmutablePorts.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/agent/Registration.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/Registration.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableRegistration.class)
 @JsonDeserialize(as = ImmutableRegistration.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -87,7 +88,7 @@ public abstract class Registration {
 
         @JsonProperty("Timeout")
         public abstract Optional<String> getTimeout();
-        
+
         @JsonProperty("Notes")
         public abstract Optional<String> getNotes();
 
@@ -129,7 +130,7 @@ public abstract class Registration {
                     .timeout(String.format("%ss", timeout))
                     .build();
         }
-        
+
         public static RegCheck args(List<String> args, long interval, long timeout, String notes) {
             return ImmutableRegCheck
                     .builder()
@@ -156,7 +157,7 @@ public abstract class Registration {
                     .timeout(String.format("%ss", timeout))
                     .build();
         }
-        
+
         public static RegCheck http(String http, long interval, long timeout, String notes) {
             return ImmutableRegCheck
                     .builder()
@@ -183,7 +184,7 @@ public abstract class Registration {
                     .timeout(String.format("%ss", timeout))
                     .build();
         }
-        
+
         public static RegCheck tcp(String tcp, long interval, long timeout, String notes) {
             return ImmutableRegCheck
                     .builder()

--- a/src/main/java/org/kiwiproject/consul/model/agent/ServiceProxy.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/ServiceProxy.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableServiceProxy.class)
 @JsonDeserialize(as = ImmutableServiceProxy.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/agent/ServiceProxyUpstream.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/ServiceProxyUpstream.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableServiceProxyUpstream.class)
 @JsonDeserialize(as = ImmutableServiceProxyUpstream.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/agent/Telemetry.java
+++ b/src/main/java/org/kiwiproject/consul/model/agent/Telemetry.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableTelemetry.class)
 @JsonDeserialize(as = ImmutableTelemetry.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/catalog/CatalogDeregistration.java
+++ b/src/main/java/org/kiwiproject/consul/model/catalog/CatalogDeregistration.java
@@ -9,6 +9,7 @@ import org.immutables.value.Value;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableCatalogDeregistration.class)
 @JsonDeserialize(as = ImmutableCatalogDeregistration.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/catalog/CatalogNode.java
+++ b/src/main/java/org/kiwiproject/consul/model/catalog/CatalogNode.java
@@ -11,6 +11,7 @@ import org.kiwiproject.consul.model.health.Service;
 import java.util.Map;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableCatalogNode.class)
 @JsonDeserialize(as = ImmutableCatalogNode.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/catalog/CatalogRegistration.java
+++ b/src/main/java/org/kiwiproject/consul/model/catalog/CatalogRegistration.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableCatalogRegistration.class)
 @JsonDeserialize(as = ImmutableCatalogRegistration.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/catalog/CatalogService.java
+++ b/src/main/java/org/kiwiproject/consul/model/catalog/CatalogService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableCatalogService.class)
 @JsonDeserialize(as = ImmutableCatalogService.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/catalog/ServiceWeights.java
+++ b/src/main/java/org/kiwiproject/consul/model/catalog/ServiceWeights.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableServiceWeights.class)
 @JsonDeserialize(as = ImmutableServiceWeights.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/catalog/TaggedAddresses.java
+++ b/src/main/java/org/kiwiproject/consul/model/catalog/TaggedAddresses.java
@@ -10,6 +10,7 @@ import org.immutables.value.Value;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableTaggedAddresses.class)
 @JsonDeserialize(as = ImmutableTaggedAddresses.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/catalog/WriteRequest.java
+++ b/src/main/java/org/kiwiproject/consul/model/catalog/WriteRequest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableWriteRequest.class)
 @JsonDeserialize(as = ImmutableWriteRequest.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/coordinate/Coord.java
+++ b/src/main/java/org/kiwiproject/consul/model/coordinate/Coord.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSerialize(as = ImmutableCoord.class)
 @JsonDeserialize(as = ImmutableCoord.class)

--- a/src/main/java/org/kiwiproject/consul/model/coordinate/Coordinate.java
+++ b/src/main/java/org/kiwiproject/consul/model/coordinate/Coordinate.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSerialize(as = ImmutableCoordinate.class)
 @JsonDeserialize(as = ImmutableCoordinate.class)

--- a/src/main/java/org/kiwiproject/consul/model/coordinate/Datacenter.java
+++ b/src/main/java/org/kiwiproject/consul/model/coordinate/Datacenter.java
@@ -9,6 +9,7 @@ import org.immutables.value.Value;
 import java.util.List;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonSerialize(as = ImmutableDatacenter.class)
 @JsonDeserialize(as = ImmutableDatacenter.class)

--- a/src/main/java/org/kiwiproject/consul/model/event/Event.java
+++ b/src/main/java/org/kiwiproject/consul/model/event/Event.java
@@ -9,6 +9,7 @@ import org.kiwiproject.consul.util.Base64EncodingDeserializer;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableEvent.class)
 @JsonDeserialize(as = ImmutableEvent.class)
 public abstract class Event {

--- a/src/main/java/org/kiwiproject/consul/model/health/HealthCheck.java
+++ b/src/main/java/org/kiwiproject/consul/model/health/HealthCheck.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableHealthCheck.class)
 @JsonDeserialize(as = ImmutableHealthCheck.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/health/Node.java
+++ b/src/main/java/org/kiwiproject/consul/model/health/Node.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableNode.class)
 @JsonDeserialize(as = ImmutableNode.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -21,7 +22,7 @@ public abstract class Node {
 
     @JsonProperty("Address")
     public abstract String getAddress();
-    
+
     @JsonProperty("Datacenter")
     public abstract Optional<String> getDatacenter();
 

--- a/src/main/java/org/kiwiproject/consul/model/health/Service.java
+++ b/src/main/java/org/kiwiproject/consul/model/health/Service.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableService.class)
 @JsonDeserialize(as = ImmutableService.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -30,7 +31,7 @@ public abstract class Service {
     @JsonProperty("Tags")
     @JsonDeserialize(as = ImmutableList.class, contentAs = String.class)
     public abstract List<String> getTags();
-    
+
     @JsonProperty("Address")
     public abstract String getAddress();
 

--- a/src/main/java/org/kiwiproject/consul/model/health/ServiceCheck.java
+++ b/src/main/java/org/kiwiproject/consul/model/health/ServiceCheck.java
@@ -10,6 +10,7 @@ import org.immutables.value.Value;
 import java.util.List;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableServiceCheck.class)
 @JsonDeserialize(as = ImmutableServiceCheck.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/health/ServiceHealth.java
+++ b/src/main/java/org/kiwiproject/consul/model/health/ServiceHealth.java
@@ -9,6 +9,7 @@ import org.immutables.value.Value;
 
 import java.util.List;
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableServiceHealth.class)
 @JsonDeserialize(as = ImmutableServiceHealth.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -23,5 +24,5 @@ public abstract class ServiceHealth {
     @JsonProperty("Checks")
     @JsonDeserialize(as = ImmutableList.class, contentAs = HealthCheck.class)
     public abstract List<HealthCheck> getChecks();
-    
+
 }

--- a/src/main/java/org/kiwiproject/consul/model/kv/Operation.java
+++ b/src/main/java/org/kiwiproject/consul/model/kv/Operation.java
@@ -12,6 +12,7 @@ import java.math.BigInteger;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableOperation.class)
 @JsonSerialize(as = ImmutableOperation.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/kv/TxError.java
+++ b/src/main/java/org/kiwiproject/consul/model/kv/TxError.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
 import java.math.BigInteger;
 import java.util.Optional;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableTxError.class)
 @JsonSerialize(as = ImmutableTxError.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/kv/TxResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/kv/TxResponse.java
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
 
 import java.util.List;
 import java.util.Map;
 
 @Immutable
+@Style(jakarta = true)
 @JsonDeserialize(as = ImmutableTxResponse.class)
 @JsonSerialize(as = ImmutableTxResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/kv/Value.java
+++ b/src/main/java/org/kiwiproject/consul/model/kv/Value.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value.Style;
 import org.immutables.value.Value.Lazy;
 import org.kiwiproject.consul.util.UnsignedLongDeserializer;
 
@@ -14,6 +15,7 @@ import java.util.Base64;
 import java.util.Optional;
 
 @Immutable
+@Style(jakarta = true)
 @JsonDeserialize(as = ImmutableValue.class)
 @JsonSerialize(as = ImmutableValue.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/operator/RaftConfiguration.java
+++ b/src/main/java/org/kiwiproject/consul/model/operator/RaftConfiguration.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
 import java.math.BigInteger;
 import java.util.List;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableRaftConfiguration.class)
 @JsonSerialize(as = ImmutableRaftConfiguration.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/operator/RaftServer.java
+++ b/src/main/java/org/kiwiproject/consul/model/operator/RaftServer.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableRaftServer.class)
 @JsonSerialize(as = ImmutableRaftServer.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/DnsQuery.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/DnsQuery.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableDnsQuery.class)
 @JsonSerialize(as = ImmutableDnsQuery.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/Failover.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/Failover.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
 import java.util.List;
 import java.util.Optional;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableFailover.class)
 @JsonSerialize(as = ImmutableFailover.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/PreparedQuery.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/PreparedQuery.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
 import java.util.Optional;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutablePreparedQuery.class)
 @JsonSerialize(as = ImmutablePreparedQuery.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/QueryId.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/QueryId.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableQueryId.class)
 @JsonSerialize(as = ImmutableQueryId.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/QueryResult.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/QueryResult.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableQueryResult.class)
 @JsonDeserialize(as = ImmutableQueryResult.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/QueryResults.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/QueryResults.java
@@ -10,6 +10,7 @@ import org.kiwiproject.consul.model.health.ServiceHealth;
 import java.util.List;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableQueryResults.class)
 @JsonDeserialize(as = ImmutableQueryResults.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/RaftIndex.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/RaftIndex.java
@@ -3,9 +3,10 @@ package org.kiwiproject.consul.model.query;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableRaftIndex.class)
 @JsonSerialize(as = ImmutableRaftIndex.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/ServiceQuery.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/ServiceQuery.java
@@ -4,12 +4,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
 import java.util.List;
 import java.util.Optional;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableServiceQuery.class)
 @JsonSerialize(as = ImmutableServiceQuery.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/StoredQuery.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/StoredQuery.java
@@ -4,9 +4,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableStoredQuery.class)
 @JsonSerialize(as = ImmutableStoredQuery.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/query/Template.java
+++ b/src/main/java/org/kiwiproject/consul/model/query/Template.java
@@ -4,11 +4,12 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.immutables.value.Value.Immutable;
+import org.immutables.value.Value;
 
 import java.util.Optional;
 
-@Immutable
+@Value.Immutable
+@Value.Style(jakarta = true)
 @JsonDeserialize(as = ImmutableTemplate.class)
 @JsonSerialize(as = ImmutableTemplate.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/session/Session.java
+++ b/src/main/java/org/kiwiproject/consul/model/session/Session.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableSession.class)
 @JsonDeserialize(as = ImmutableSession.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/session/SessionCreatedResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/session/SessionCreatedResponse.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableSessionCreatedResponse.class)
 @JsonDeserialize(as = ImmutableSessionCreatedResponse.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/model/session/SessionInfo.java
+++ b/src/main/java/org/kiwiproject/consul/model/session/SessionInfo.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 @JsonSerialize(as = ImmutableSessionInfo.class)
 @JsonDeserialize(as = ImmutableSessionInfo.class)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/java/org/kiwiproject/consul/option/DeleteOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/DeleteOptions.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 public abstract class DeleteOptions implements ParamAdder {
 
     public static final DeleteOptions BLANK = ImmutableDeleteOptions.builder().build();

--- a/src/main/java/org/kiwiproject/consul/option/EventOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/EventOptions.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 public abstract class EventOptions implements ParamAdder {
 
     public static final EventOptions BLANK = ImmutableEventOptions.builder().build();

--- a/src/main/java/org/kiwiproject/consul/option/PutOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/PutOptions.java
@@ -7,10 +7,11 @@ import java.util.Map;
 import java.util.Optional;
 
 @Value.Immutable
+@Value.Style(jakarta = true)
 public abstract class PutOptions implements ParamAdder {
-    
+
     public static final PutOptions BLANK = ImmutablePutOptions.builder().build();
-    
+
     public abstract Optional<Long> getCas();
     public abstract Optional<String> getAcquire();
     public abstract Optional<String> getRelease();

--- a/src/main/java/org/kiwiproject/consul/option/QueryOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/QueryOptions.java
@@ -14,6 +14,7 @@ import java.util.Optional;
  * Container for common query options used by the Consul API.
  */
 @Value.Immutable
+@Value.Style(jakarta = true)
 public abstract class QueryOptions implements ParamAdder {
 
     public static final QueryOptions BLANK = ImmutableQueryOptions.builder().build();

--- a/src/main/java/org/kiwiproject/consul/option/QueryParameterOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/QueryParameterOptions.java
@@ -12,6 +12,7 @@ import java.util.Optional;
  * Container for common query options used by the Consul API.
  */
 @Value.Immutable
+@Value.Style(jakarta = true)
 public abstract class QueryParameterOptions implements ParamAdder {
 
     public static final QueryParameterOptions BLANK = ImmutableQueryParameterOptions.builder().build();

--- a/src/main/java/org/kiwiproject/consul/option/RoleOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/RoleOptions.java
@@ -10,6 +10,7 @@ import java.util.Optional;
  * Container for common query options used by the Consul API.
  */
 @Value.Immutable
+@Value.Style(jakarta = true)
 public abstract class RoleOptions implements ParamAdder {
 
     public static final RoleOptions BLANK = ImmutableRoleOptions.builder().build();

--- a/src/main/java/org/kiwiproject/consul/option/TokenQueryOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/TokenQueryOptions.java
@@ -10,6 +10,7 @@ import java.util.Optional;
  * Container for token query options used by the Consul ACL API.
  */
 @Value.Immutable
+@Value.Style(jakarta = true)
 public abstract class TokenQueryOptions implements ParamAdder {
 
     public static final TokenQueryOptions BLANK = ImmutableTokenQueryOptions.builder().build();

--- a/src/main/java/org/kiwiproject/consul/option/TransactionOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/TransactionOptions.java
@@ -10,6 +10,7 @@ import java.util.Optional;
  * Container for common transaction options used by the Consul API.
  */
 @Value.Immutable
+@Value.Style(jakarta = true)
 public abstract class TransactionOptions implements ParamAdder {
 
     public static final TransactionOptions BLANK = ImmutableTransactionOptions.builder().build();


### PR DESCRIPTION
* Add jakarta.annotation-api as a compile-scope dependency, since the generated classes will contain jakarta annotations
* Add the "jakarta = true" style to all the classes using Immutables
* Note that Value and TxResponse (which uses Value) must import org.immutables.value.Value.Immutable and org.immutables.value.Value.Style because otherwise, they conflict with org.kiwiproject.consul.model.kv.Value. All other model classes import org.immutables.value.Value and then use the annotations as Value.Immutable and Value.Style. I retained this semantic, which was how these classes were originally defined well before we forked this project.

Closes #283