### PR TITLE
Code cleanup

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
@@ -24,6 +24,8 @@ import org.kiwiproject.consul.option.ImmutableDeleteOptions;
 import org.kiwiproject.consul.option.ImmutableQueryOptions;
 import org.kiwiproject.consul.option.PutOptions;
 import org.kiwiproject.consul.option.QueryOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.nio.charset.Charset;
 import java.util.HashSet;
@@ -38,6 +40,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class KeyValueClientITest extends BaseIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KeyValueClientITest.class);
 
     private static final Charset TEST_CHARSET = Charset.forName("IBM297");
 
@@ -398,7 +402,7 @@ class KeyValueClientITest extends BaseIntegrationTest {
 
             @Override
             public void onFailure(Throwable throwable) {
-                throwable.printStackTrace();
+                LOG.error("getValues failed for key {}", key, throwable);
                 completed.countDown();
             }
         });

--- a/src/main/java/org/kiwiproject/consul/model/ConsulResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/ConsulResponse.java
@@ -100,6 +100,7 @@ public class ConsulResponse<T> {
      * @deprecated replaced by {@link #getCacheResponseInfo()}
      * @see <a href="https://developer.hashicorp.com/consul/api-docs/features/caching#background-refresh-caching">Background Refresh Caching</a>
      */
+    @SuppressWarnings("DeprecatedIsStillUsed")
     @Deprecated(since = "1.1.0", forRemoval = true)
     public Optional<CacheResponseInfo> getCacheReponseInfo(){
         return getCacheResponseInfo();


### PR DESCRIPTION
* Suppress warning in ConsulResponse that deprecated code is still used
* Replace printStackTrace() with Logger in KeyValueClientITest