### PR TITLE
Log warning if Consul failover interceptor is set multiple times

### DIFF
--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -505,6 +505,11 @@ public class Consul {
          * Sets the list of hosts to contact if the current request target is
          * unavailable. When the call to a particular URL fails for any reason, the next {@link HostAndPort} specified
          * is used to retry the request. This will continue until all urls are exhausted.
+         * <p>
+         * Internally, this method constructs a {@link ConsulFailoverInterceptor} with a
+         * {@link org.kiwiproject.consul.util.failover.strategy.BlacklistingConsulFailoverStrategy BlacklistingConsulFailoverStrategy}.
+         * If you call this method, you should not use {@link #withFailoverInterceptor(ConsulFailoverStrategy)}
+         * as it will create a new failover interceptor which overrides the one set by this method.
          *
          * @param hostAndPort           A collection of {@link HostAndPort} that define the list of Consul agent addresses to use.
          * @param blacklistTimeInMillis The timeout (in milliseconds) to blacklist a particular {@link HostAndPort} before trying to use it again.
@@ -524,6 +529,10 @@ public class Consul {
 
         /**
          * Constructs a failover interceptor with the given {@link ConsulFailoverStrategy}.
+         * <p>
+         * If you call this method, you should not use {@link #withMultipleHostAndPort(Collection, long)}
+         * as it will create a new failover interceptor which overrides the one set by this method.
+         *
          * @param strategy The strategy to use.
          * @return The builder.
          */

--- a/src/test/java/org/kiwiproject/consul/ConsulTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulTest.java
@@ -1,7 +1,9 @@
 package org.kiwiproject.consul;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
 
 import com.google.common.net.HostAndPort;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +13,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.consul.util.failover.strategy.ConsulFailoverStrategy;
 
 import java.util.Collection;
 import java.util.List;
@@ -57,6 +60,36 @@ class ConsulTest {
             assertThatIllegalArgumentException()
                     .isThrownBy(() -> Consul.builder().withFailoverInterceptor(null))
                     .withMessage("Must not provide a null strategy");
+        }
+    }
+
+    @Nested
+    class WithMultipleFailoverInterceptors {
+
+        @Test
+        void shouldDetectWhenConsulInterceptorAlreadySetBy_withMultipleHostAndPort() {
+            var hosts = List.of(
+                    HostAndPort.fromString("consul1.acme.com:8500"),
+                    HostAndPort.fromString("consul2.acme.com:8500")
+            );
+            var consulBuilder = Consul.builder()
+                    .withMultipleHostAndPort(hosts, 10_000)
+                    .withFailoverInterceptor(mock(ConsulFailoverStrategy.class));
+
+            assertThat(consulBuilder.numTimesConsulFailoverInterceptorSet()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldDetectWhenConsulInterceptorAlreadySetBy_withFailoverInterceptor() {
+            var hosts = List.of(
+                    HostAndPort.fromString("consul1.acme.com:8500"),
+                    HostAndPort.fromString("consul2.acme.com:8500")
+            );
+            var consulBuilder = Consul.builder()
+                    .withFailoverInterceptor(mock(ConsulFailoverStrategy.class))
+                    .withMultipleHostAndPort(hosts, 7_500);
+
+            assertThat(consulBuilder.numTimesConsulFailoverInterceptorSet()).isEqualTo(2);
         }
     }
 }


### PR DESCRIPTION
* Log a warning in Consul if both withMultipleHostAndPort and withFailoverInterceptor are called when building a Consul instance.
* This is important because calling them both results in a "last one wins" scenario, since the last method called sets the failover interceptor.

Closes #306