### PR TITLE
Add withConsulFailoverInterceptor to Consul.Builder

### DIFF
--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -503,6 +503,21 @@ public class Consul {
         }
 
         /**
+         * Uses the given failover interceptor.
+         *
+         * @param failoverInterceptor the failover interceptor to use
+         * @return The builder.
+         */
+        public Builder withConsulFailoverInterceptor(ConsulFailoverInterceptor failoverInterceptor) {
+            checkArgument(nonNull(failoverInterceptor), "failoverInterceptor must not be null");
+            logWarningIfConsulFailoverInterceptorAlreadySet("withConsulFailoverInterceptor");
+
+            this.consulFailoverInterceptor = failoverInterceptor;
+            ++numTimesConsulFailoverInterceptorSet;
+            return this;
+        }
+
+        /**
          * Sets the list of hosts to contact if the current request target is
          * unavailable. When the call to a particular URL fails for any reason, the next {@link HostAndPort} specified
          * is used to retry the request. This will continue until all urls are exhausted.
@@ -584,8 +599,8 @@ public class Consul {
         private void logWarningIfConsulFailoverInterceptorAlreadySet(String methodName) {
             if (numTimesConsulFailoverInterceptorSet > 0) {
                 LOG.warn("A ConsulFailoverInterceptor was already present; this invocation to '{}' overrides it!" +
-                                " Make sure either 'withMultipleHostAndPort' or 'withFailoverInterceptor' is called," +
-                                " but not both.",
+                                " Make sure only one of 'withConsulFailoverInterceptor'," +
+                                " 'withMultipleHostAndPort' or 'withFailoverInterceptor' is called.",
                         methodName);
             }
         }

--- a/src/test/java/org/kiwiproject/consul/ConsulTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.kiwiproject.consul.util.failover.ConsulFailoverInterceptor;
 import org.kiwiproject.consul.util.failover.strategy.ConsulFailoverStrategy;
 
 import java.time.Duration;
@@ -82,6 +83,17 @@ class ConsulTest {
     }
 
     @Nested
+    class WithConsulFailoverInterceptor {
+
+        @Test
+        void shouldRequireNonNullInterceptor() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> Consul.builder().withConsulFailoverInterceptor(null))
+                    .withMessage("failoverInterceptor must not be null");
+        }
+    }
+
+    @Nested
     class WithMultipleFailoverInterceptors {
 
         @Test
@@ -92,6 +104,16 @@ class ConsulTest {
             );
             var consulBuilder = Consul.builder()
                     .withMultipleHostAndPort(hosts, Duration.ofSeconds(10))
+                    .withFailoverInterceptor(mock(ConsulFailoverStrategy.class));
+
+            assertThat(consulBuilder.numTimesConsulFailoverInterceptorSet()).isEqualTo(2);
+        }
+
+        @Test
+        void shouldDetectWhenConsulInterceptorAlreadySetBy_withConsulFailoverInterceptor() {
+            var failoverInterceptor = new ConsulFailoverInterceptor(mock(ConsulFailoverStrategy.class));
+            var consulBuilder = Consul.builder()
+                    .withConsulFailoverInterceptor(failoverInterceptor)
                     .withFailoverInterceptor(mock(ConsulFailoverStrategy.class));
 
             assertThat(consulBuilder.numTimesConsulFailoverInterceptorSet()).isEqualTo(2);


### PR DESCRIPTION
* This allows for directly setting a ConsulFailoverInterceptor.
* Update message in logWarningIfConsulFailoverInterceptorAlreadySet to include all three of the methods that can set the failover interceptor.

Closes #313