### PR TITLE
Add the ability to set max failover attempts building Consul instances

### DIFF
--- a/src/test/java/org/kiwiproject/consul/ConsulTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulTest.java
@@ -154,4 +154,21 @@ class ConsulTest {
             assertThat(consulBuilder.numTimesConsulFailoverInterceptorSet()).isEqualTo(2);
         }
     }
+
+    @Nested
+    class WithMaxFailoverAttempts {
+
+        @ParameterizedTest
+        @ValueSource(ints = { -10, -5, -1, 0 })
+        void shouldRequirePositiveNumbers(int maxFailoverAttempts) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> Consul.builder().withMaxFailoverAttempts(maxFailoverAttempts));
+        }
+
+        @Test
+        void shouldReturnTheBuilder() {
+            var builder = Consul.builder();
+            assertThat(builder.withMaxFailoverAttempts(5)).isSameAs(builder);
+        }
+    }
 }


### PR DESCRIPTION
* Add withMaxFailoverAttempts to Consul.Builder
* Add int maxFailoverAttempts field to Consul.Builder to track whether the withMaxFailoverAttempts method was called
* Change the type of the consulFailoverInterceptor field from the generic Interceptor to ConsulFailoverInterceptor, so that we can call its withMaxFailoverAttempts method
* In Consul.Builder#createOkHttpClient, set the maxFailoverAttempts on the ConsulFailoverInterceptor if it was set on the builder (i.e., it has a value greater than zero)

Closes #312