### PR TITLE
Use static imports for AssertJ Assertions

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/AgentClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/AgentClientITest.java
@@ -9,7 +9,6 @@ import static org.kiwiproject.consul.Awaiting.awaitAtMost500ms;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
 
 import com.google.common.net.HostAndPort;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.RepeatedTest;
@@ -82,9 +81,9 @@ class AgentClientITest extends BaseIntegrationTest {
 
         Assumptions.assumeThat(agent.getDebugConfig()).isNotNull();
 
-        Assertions.assertThat(agent).isNotNull();
-        Assertions.assertThat(agent.getConfig()).isNotNull();
-        Assertions.assertThat(agent.getDebugConfig()).isNotNull();
+        assertThat(agent).isNotNull();
+        assertThat(agent.getConfig()).isNotNull();
+        assertThat(agent.getDebugConfig()).isNotNull();
         final List<?> clientAddrs = (List<?>) agent.getDebugConfig().get("ClientAddrs");
         assertThat(clientAddrs.get(0)).isNotNull();
 
@@ -332,7 +331,7 @@ class AgentClientITest extends BaseIntegrationTest {
                 .build();
 
         var registeredService = findService(service -> service.getId().equals(serviceId)).orElseThrow();
-        Assertions.assertThat(registeredService).isEqualTo(expectedService);
+        assertThat(registeredService).isEqualTo(expectedService);
     }
 
     @Test
@@ -365,7 +364,7 @@ class AgentClientITest extends BaseIntegrationTest {
         var services = agentClient.getServices(queryOptions).values();
 
         var registeredService = findService(services, service -> service.getId().equals(serviceId)).orElseThrow();
-        Assertions.assertThat(registeredService).isEqualTo(expectedService);
+        assertThat(registeredService).isEqualTo(expectedService);
     }
 
     @Test

--- a/src/itest/java/org/kiwiproject/consul/CatalogClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/CatalogClientITest.java
@@ -6,7 +6,6 @@ import static org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
 import static org.kiwiproject.consul.Awaiting.awaitWith25MsPoll;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.consul.async.ConsulResponseCallback;
@@ -107,10 +106,10 @@ class CatalogClientITest extends BaseIntegrationTest {
         List<Node> nodesResp = catalogClient.getNodes().getResponse();
         assertThat(nodesResp).isNotEmpty();
         for (var node : nodesResp) {
-            Assertions.assertThat(node.getTaggedAddresses()).isNotNull();
+            assertThat(node.getTaggedAddresses()).isNotNull();
             if (node.getTaggedAddresses().isPresent()) {
-                Assertions.assertThat(node.getTaggedAddresses().get().getWan()).isNotNull();
-                Assertions.assertThat(node.getTaggedAddresses().get().getWan()).isNotEmpty();
+                assertThat(node.getTaggedAddresses().get().getWan()).isNotNull();
+                assertThat(node.getTaggedAddresses().get().getWan()).isNotEmpty();
             }
         }
     }
@@ -121,10 +120,10 @@ class CatalogClientITest extends BaseIntegrationTest {
         assertThat(nodesResp).isNotEmpty();
         for (var tmpNode : nodesResp) {
             var node = catalogClient.getNode(tmpNode.getNode()).getResponse().getNode();
-            Assertions.assertThat(node.getTaggedAddresses()).isNotNull();
+            assertThat(node.getTaggedAddresses()).isNotNull();
             if (node.getTaggedAddresses().isPresent()) {
-                Assertions.assertThat(node.getTaggedAddresses().get().getWan()).isNotNull();
-                Assertions.assertThat(node.getTaggedAddresses().get().getWan()).isNotEmpty();
+                assertThat(node.getTaggedAddresses().get().getWan()).isNotNull();
+                assertThat(node.getTaggedAddresses().get().getWan()).isNotEmpty();
             }
         }
     }
@@ -340,7 +339,7 @@ class CatalogClientITest extends BaseIntegrationTest {
     private void createAndCheckService(CatalogService expectedService, CatalogRegistration registration) {
         catalogClient.register(registration);
 
-        Assertions.assertThat(registration.service()).isPresent();
+        assertThat(registration.service()).isPresent();
         var serviceName = registration.service().orElseThrow().getService();
 
         var foundServiceRef = new AtomicReference<CatalogService>();


### PR DESCRIPTION
There were still two remaining tests containing "Assertions.assertThat." Replace with static import of Assertions.assertThat.