### PR TITLE
Code cleanup: replace conditional with stream in LeaderElectionUtil

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/util/LeaderElectionUtilITest.java
+++ b/src/itest/java/org/kiwiproject/consul/util/LeaderElectionUtilITest.java
@@ -13,9 +13,10 @@ class LeaderElectionUtilITest extends BaseIntegrationTest {
         var serviceName = "myservice100";
         var serviceInfo = "serviceinfo";
 
-        leaderElection.releaseLockForService(serviceName);
+        assertThat(leaderElection.releaseLockForService(serviceName)).isFalse();
         assertThat(leaderElection.getLeaderInfoForService(serviceName)).isEmpty();
         assertThat(leaderElection.electNewLeaderForService(serviceName, serviceInfo)).contains(serviceInfo);
         assertThat(leaderElection.releaseLockForService(serviceName)).isTrue();
+        assertThat(leaderElection.getLeaderInfoForService(serviceName)).isEmpty();
     }
 }

--- a/src/main/java/org/kiwiproject/consul/util/LeaderElectionUtil.java
+++ b/src/main/java/org/kiwiproject/consul/util/LeaderElectionUtil.java
@@ -7,6 +7,7 @@ import org.kiwiproject.consul.model.session.ImmutableSession;
 import org.kiwiproject.consul.model.session.Session;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 public class LeaderElectionUtil {
 
@@ -41,11 +42,11 @@ public class LeaderElectionUtil {
         final String key = getServiceKey(serviceName);
         KeyValueClient kv = client.keyValueClient();
         Optional<Value> value = kv.getValue(key);
-        if (value.isPresent() && value.get().getSession().isPresent()) {
-            return kv.releaseLock(key, value.get().getSession().get());
-        } else {
-            return true;
-        }
+
+        return value.map(Value::getSession)
+                .flatMap(Function.identity())
+                .map(sessionId -> kv.releaseLock(key, sessionId))
+                .orElse(false);
     }
 
 


### PR DESCRIPTION
* Replace conditional with long method call chains with stream
* Enhance test by asserting that the first call to releaseLockForService returns false, because there was no lock held. Then, after a lock was obtained and subsequently released, add an assertion that there is no leader.