### PR TITLE
Sonar cleanup

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/AclClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/AclClientITest.java
@@ -33,9 +33,9 @@ class AclClientITest {
     private static GenericContainer<?> consulContainerAcl;
     private static AclClient aclClient;
 
+    @SuppressWarnings("resource")
     @BeforeAll
     static void beforeAll() {
-        // noinspection resource
         consulContainerAcl = new GenericContainer<>(CONSUL_DOCKER_IMAGE_NAME)
                 .withCommand("agent", "-dev", "-client", "0.0.0.0", "--enable-script-checks=true")
                 .withExposedPorts(8500)

--- a/src/itest/java/org/kiwiproject/consul/AgentClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/AgentClientITest.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.consul;
 
 import static java.util.Objects.nonNull;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
@@ -596,7 +595,7 @@ class AgentClientITest extends BaseIntegrationTest {
                 .getNodeChecks(node, QueryOptions.BLANK).getResponse()
                 .stream()
                 .map(HealthCheck::getName)
-                .collect(toList());
+                .toList();
     }
 
     private void verifyState(String state, Consul client, String serviceId, String serviceName, String output) {

--- a/src/itest/java/org/kiwiproject/consul/BaseIntegrationTest.java
+++ b/src/itest/java/org/kiwiproject/consul/BaseIntegrationTest.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+@SuppressWarnings("resource")
 public abstract class BaseIntegrationTest {
 
     private static final Logger LOG = LoggerFactory.getLogger(BaseIntegrationTest.class);
@@ -39,7 +40,6 @@ public abstract class BaseIntegrationTest {
     // https://github.com/junit-team/junit5/issues/456#issuecomment-416945159
 
     static {
-        // noinspection resource
         consulContainer = new GenericContainer<>(CONSUL_DOCKER_IMAGE_NAME)
                 .withCommand("agent", "-dev", "-client", "0.0.0.0", "--enable-script-checks=true")
                 .withExposedPorts(8500);

--- a/src/itest/java/org/kiwiproject/consul/EventClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/EventClientITest.java
@@ -1,7 +1,6 @@
 package org.kiwiproject.consul;
 
 import static java.util.Objects.nonNull;
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Durations.TWO_HUNDRED_MILLISECONDS;
 import static org.kiwiproject.consul.Awaiting.awaitAtMost1s;
@@ -156,11 +155,11 @@ class EventClientITest extends BaseIntegrationTest {
     }
 
     private List<String> createRandomEventsGettingIds(int eventCount) {
-        return createRandomEventsAsStream(eventCount).map(Event::getId).collect(toList());
+        return createRandomEventsAsStream(eventCount).map(Event::getId).toList();
     }
 
     private List<Event> createRandomEvents(int eventCount) {
-        return createRandomEventsAsStream(eventCount).collect(toList());
+        return createRandomEventsAsStream(eventCount).toList();
     }
 
     private Stream<Event> createRandomEventsAsStream(int eventCount) {
@@ -169,7 +168,7 @@ class EventClientITest extends BaseIntegrationTest {
     }
 
     List<String> getEventIds(EventResponse eventResponse) {
-        return eventResponse.getEvents().stream().map(Event::getId).collect(toList());
+        return eventResponse.getEvents().stream().map(Event::getId).toList();
     }
 
     List<String> getEventIds(TestEventResponseCallback callback) {
@@ -177,7 +176,7 @@ class EventClientITest extends BaseIntegrationTest {
     }
 
     List<String> getEventIds(Collection<Event> events) {
-        return events.stream().map(Event::getId).collect(toList());
+        return events.stream().map(Event::getId).toList();
     }
 
     Collection<Event> getEvents(TestEventResponseCallback callback) {

--- a/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.consul;
 
-import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toUnmodifiableMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
@@ -212,7 +212,7 @@ class KeyValueClientITest extends BaseIntegrationTest {
 
         var valuesMap = keyValueClient.getValues(topLevelKey)
                 .stream()
-                .collect(toMap(Value::getKey, value -> value.getValueAsString().orElseThrow()));
+                .collect(toUnmodifiableMap(Value::getKey, value -> value.getValueAsString().orElseThrow()));
 
         assertThat(valuesMap).containsOnly(
                 entry(key1, value1),

--- a/src/itest/java/org/kiwiproject/consul/PreparedQueryClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/PreparedQueryClientITest.java
@@ -1,6 +1,5 @@
 package org.kiwiproject.consul;
 
-import static java.util.stream.Collectors.toList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
 
@@ -135,10 +134,10 @@ class PreparedQueryClientITest extends BaseIntegrationTest {
 
         assertThat(storedQueries).hasSize(2);
 
-        List<String> queryIds = storedQueries.stream().map(StoredQuery::getId).collect(toList());
+        List<String> queryIds = storedQueries.stream().map(StoredQuery::getId).toList();
         assertThat(queryIds).contains(id1, id2);
 
-        List<String> queryNames = storedQueries.stream().map(StoredQuery::getName).collect(toList());
+        List<String> queryNames = storedQueries.stream().map(StoredQuery::getName).toList();
         assertThat(queryNames).contains(query1, query2);
     }
 

--- a/src/test/java/org/kiwiproject/consul/config/CacheConfigTest.java
+++ b/src/test/java/org/kiwiproject/consul/config/CacheConfigTest.java
@@ -283,7 +283,8 @@ class CacheConfigTest {
             final CallbackConsumer<Integer> callbackConsumer = (index, callback) ->
                     callback.onComplete(new ConsulResponse<>(responseSupplier.get(), 0, true, BigInteger.ZERO, null, null));
 
-            return new TestCache((i) -> i,
+            return new TestCache(
+                    i -> i,
                     callbackConsumer,
                     config,
                     clientEventHandler,

--- a/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
@@ -2,13 +2,13 @@ package org.kiwiproject.consul.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.io.BaseEncoding;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.consul.model.event.Event;
 import org.kiwiproject.consul.model.event.ImmutableEvent;
 
 import java.io.IOException;
+import java.util.Base64;
 
 class Base64EncodingDeserializerTest {
 
@@ -20,7 +20,7 @@ class Base64EncodingDeserializerTest {
                 .lTime(1L)
                 .name("name")
                 .version(1)
-                .payload(BaseEncoding.base64().encode(value.getBytes()))
+                .payload(Base64.getEncoder().encodeToString(value.getBytes()))
                 .build();
 
         String serializedEvent = Jackson.MAPPER.writeValueAsString(event);

--- a/src/test/java/org/kiwiproject/consul/util/HttpTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/HttpTest.java
@@ -43,7 +43,7 @@ class HttpTest {
     }
 
     private <T> Function<Call<T>, T> createExtractWrapper() {
-        return (call) -> http.extract(call);
+        return call -> http.extract(call);
     }
 
     private Function<Call<Void>, Void> createHandleWrapper() {
@@ -54,7 +54,7 @@ class HttpTest {
     }
 
     private <T> Function<Call<T>, ConsulResponse<T>> createExtractConsulResponseWrapper() {
-        return (call) -> http.extractConsulResponse(call);
+        return call -> http.extractConsulResponse(call);
     }
 
     @Test


### PR DESCRIPTION
* "Stream.toList()" method should be used instead of "collectors" when unmodifiable list needed java:S6204
* Parentheses should be removed from a single lambda parameter when its type is inferred java:S1611
* Java features should be preferred to Guava java:S4738