### PR TITLE
Deprecate usage of the "options" constants for removal

### DIFF
--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -622,7 +622,7 @@ public class Consul {
          * @deprecated replaced by {@link #withFailoverInterceptorUsingStrategy(ConsulFailoverStrategy)}
          */
         @SuppressWarnings("DeprecatedIsStillUsed")
-        @Deprecated(since = "1.3.0", forRemoval = true)
+        @Deprecated(since = "1.3.3", forRemoval = true)
         public Builder withFailoverInterceptor(ConsulFailoverStrategy strategy) {
             return withFailoverInterceptorUsingStrategy(strategy);
         }
@@ -977,7 +977,7 @@ public class Consul {
 
         private static void addTimeouts(OkHttpClient.Builder builder,
                                         NetworkTimeoutConfig networkTimeoutConfig) {
-            
+
             if (networkTimeoutConfig.getClientConnectTimeoutMillis() >= 0) {
                 builder.connectTimeout(networkTimeoutConfig.getClientConnectTimeoutMillis(), TimeUnit.MILLISECONDS);
             }

--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -622,7 +622,7 @@ public class Consul {
          * @deprecated replaced by {@link #withFailoverInterceptorUsingStrategy(ConsulFailoverStrategy)}
          */
         @SuppressWarnings("DeprecatedIsStillUsed")
-        @Deprecated(since = "1.3.3", forRemoval = true)
+        @Deprecated(since = "1.3.0", forRemoval = true)
         public Builder withFailoverInterceptor(ConsulFailoverStrategy strategy) {
             return withFailoverInterceptorUsingStrategy(strategy);
         }

--- a/src/main/java/org/kiwiproject/consul/option/DeleteOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/DeleteOptions.java
@@ -10,9 +10,15 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class DeleteOptions implements ParamAdder {
 
+    /**
+     * @deprecated for removal in 2.0.0 (replacement will be in 1.4.0)
+     */
     @Deprecated(since = "1.3.3", forRemoval = true)
     public static final DeleteOptions BLANK = ImmutableDeleteOptions.builder().build();
 
+    /**
+     * @deprecated for removal in 2.0.0 (replacement will be in 1.4.0)
+     */
     @Deprecated(since = "1.3.3", forRemoval = true)
     public static final DeleteOptions RECURSE = ImmutableDeleteOptions.builder().recurse(true).build();
 

--- a/src/main/java/org/kiwiproject/consul/option/DeleteOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/DeleteOptions.java
@@ -10,7 +10,10 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class DeleteOptions implements ParamAdder {
 
+    @Deprecated(since = "1.3.3", forRemoval = true)
     public static final DeleteOptions BLANK = ImmutableDeleteOptions.builder().build();
+
+    @Deprecated(since = "1.3.3", forRemoval = true)
     public static final DeleteOptions RECURSE = ImmutableDeleteOptions.builder().recurse(true).build();
 
     public abstract Optional<Long> getCas();

--- a/src/main/java/org/kiwiproject/consul/option/EventOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/EventOptions.java
@@ -12,6 +12,9 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class EventOptions implements ParamAdder {
 
+    /**
+     * @deprecated for removal in 2.0.0 (replacement will be in 1.4.0)
+     */
     @Deprecated(since = "1.3.3", forRemoval = true)
     public static final EventOptions BLANK = ImmutableEventOptions.builder().build();
 

--- a/src/main/java/org/kiwiproject/consul/option/EventOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/EventOptions.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class EventOptions implements ParamAdder {
 
+    @Deprecated(since = "1.3.3", forRemoval = true)
     public static final EventOptions BLANK = ImmutableEventOptions.builder().build();
 
     public abstract Optional<String> getDatacenter();

--- a/src/main/java/org/kiwiproject/consul/option/PutOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/PutOptions.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class PutOptions implements ParamAdder {
 
+    @Deprecated(since = "1.3.3", forRemoval = true)
     public static final PutOptions BLANK = ImmutablePutOptions.builder().build();
 
     public abstract Optional<Long> getCas();

--- a/src/main/java/org/kiwiproject/consul/option/PutOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/PutOptions.java
@@ -10,6 +10,9 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class PutOptions implements ParamAdder {
 
+    /**
+     * @deprecated for removal in 2.0.0 (replacement will be in 1.4.0)
+     */
     @Deprecated(since = "1.3.3", forRemoval = true)
     public static final PutOptions BLANK = ImmutablePutOptions.builder().build();
 

--- a/src/main/java/org/kiwiproject/consul/option/QueryOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/QueryOptions.java
@@ -17,6 +17,9 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class QueryOptions implements ParamAdder {
 
+    /**
+     * @deprecated for removal in 2.0.0 (replacement will be in 1.4.0)
+     */
     @Deprecated(since = "1.3.3", forRemoval = true)
     public static final QueryOptions BLANK = ImmutableQueryOptions.builder().build();
 

--- a/src/main/java/org/kiwiproject/consul/option/QueryOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/QueryOptions.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class QueryOptions implements ParamAdder {
 
+    @Deprecated(since = "1.3.3", forRemoval = true)
     public static final QueryOptions BLANK = ImmutableQueryOptions.builder().build();
 
     public abstract Optional<String> getWait();

--- a/src/main/java/org/kiwiproject/consul/option/QueryParameterOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/QueryParameterOptions.java
@@ -15,6 +15,7 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class QueryParameterOptions implements ParamAdder {
 
+    @Deprecated(since = "1.3.3", forRemoval = true)
     public static final QueryParameterOptions BLANK = ImmutableQueryParameterOptions.builder().build();
 
     public abstract Optional<Boolean> getReplaceExistingChecks();

--- a/src/main/java/org/kiwiproject/consul/option/QueryParameterOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/QueryParameterOptions.java
@@ -15,6 +15,9 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class QueryParameterOptions implements ParamAdder {
 
+    /**
+     * @deprecated for removal in 2.0.0 (replacement will be in 1.4.0)
+     */
     @Deprecated(since = "1.3.3", forRemoval = true)
     public static final QueryParameterOptions BLANK = ImmutableQueryParameterOptions.builder().build();
 

--- a/src/main/java/org/kiwiproject/consul/option/RoleOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/RoleOptions.java
@@ -13,6 +13,9 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class RoleOptions implements ParamAdder {
 
+    /**
+     * @deprecated for removal in 2.0.0 (replacement will be in 1.4.0)
+     */
     @Deprecated(since = "1.3.3", forRemoval = true)
     public static final RoleOptions BLANK = ImmutableRoleOptions.builder().build();
 

--- a/src/main/java/org/kiwiproject/consul/option/RoleOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/RoleOptions.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class RoleOptions implements ParamAdder {
 
+    @Deprecated(since = "1.3.3", forRemoval = true)
     public static final RoleOptions BLANK = ImmutableRoleOptions.builder().build();
 
     public abstract Optional<String> getPolicy();

--- a/src/main/java/org/kiwiproject/consul/option/TokenQueryOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/TokenQueryOptions.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class TokenQueryOptions implements ParamAdder {
 
+    @Deprecated(since = "1.3.3", forRemoval = true)
     public static final TokenQueryOptions BLANK = ImmutableTokenQueryOptions.builder().build();
 
     public abstract Optional<String> getPolicy();

--- a/src/main/java/org/kiwiproject/consul/option/TokenQueryOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/TokenQueryOptions.java
@@ -13,6 +13,9 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class TokenQueryOptions implements ParamAdder {
 
+    /**
+     * @deprecated for removal in 2.0.0 (replacement will be in 1.4.0)
+     */
     @Deprecated(since = "1.3.3", forRemoval = true)
     public static final TokenQueryOptions BLANK = ImmutableTokenQueryOptions.builder().build();
 

--- a/src/main/java/org/kiwiproject/consul/option/TransactionOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/TransactionOptions.java
@@ -13,6 +13,9 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class TransactionOptions implements ParamAdder {
 
+    /**
+     * @deprecated for removal in 2.0.0 (replacement will be in 1.4.0)
+     */
     @Deprecated(since = "1.3.3", forRemoval = true)
     public static final TransactionOptions BLANK = ImmutableTransactionOptions.builder().build();
 

--- a/src/main/java/org/kiwiproject/consul/option/TransactionOptions.java
+++ b/src/main/java/org/kiwiproject/consul/option/TransactionOptions.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 @Value.Style(jakarta = true)
 public abstract class TransactionOptions implements ParamAdder {
 
+    @Deprecated(since = "1.3.3", forRemoval = true)
     public static final TransactionOptions BLANK = ImmutableTransactionOptions.builder().build();
 
     public abstract Optional<String> getDatacenter();


### PR DESCRIPTION
We don't yet have the replacements as of 1.3.3. Those will be added in 1.4.0.

Closes #356