### PR TITLE
Extract duplicate dcQuery methods to util class

### DIFF
--- a/src/main/java/org/kiwiproject/consul/ConsulClients.java
+++ b/src/main/java/org/kiwiproject/consul/ConsulClients.java
@@ -1,0 +1,21 @@
+package org.kiwiproject.consul;
+
+import static java.util.Objects.nonNull;
+
+import java.util.Map;
+
+/**
+ * A class containing shared utilities for Consul Client classes.
+ * <p>
+ * Note this is not part of the public API.
+ */
+class ConsulClients {
+
+    private ConsulClients() {
+        // utiltity class
+    }
+
+    static Map<String, String> dcQuery(String dc) {
+        return nonNull(dc) ? Map.of("dc", dc) : Map.of();
+    }
+}

--- a/src/main/java/org/kiwiproject/consul/CoordinateClient.java
+++ b/src/main/java/org/kiwiproject/consul/CoordinateClient.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.consul;
 
-import static java.util.Objects.nonNull;
+import static org.kiwiproject.consul.ConsulClients.dcQuery;
 
 import org.kiwiproject.consul.config.ClientConfig;
 import org.kiwiproject.consul.model.coordinate.Coordinate;
@@ -45,10 +45,6 @@ public class CoordinateClient extends BaseClient {
 
     public List<Coordinate> getNodes() {
         return getNodes(null);
-    }
-
-    private Map<String, String> dcQuery(String dc) {
-        return nonNull(dc) ? Map.of("dc", dc) : Map.of();
     }
 
     /**

--- a/src/main/java/org/kiwiproject/consul/PreparedQueryClient.java
+++ b/src/main/java/org/kiwiproject/consul/PreparedQueryClient.java
@@ -1,6 +1,6 @@
 package org.kiwiproject.consul;
 
-import static java.util.Objects.nonNull;
+import static org.kiwiproject.consul.ConsulClients.dcQuery;
 
 import org.kiwiproject.consul.async.Callback;
 import org.kiwiproject.consul.config.ClientConfig;
@@ -62,10 +62,6 @@ public class PreparedQueryClient extends BaseClient {
      */
     public String createPreparedQuery(PreparedQuery preparedQuery, final String dc) {
         return http.extract(api.createPreparedQuery(preparedQuery, dcQuery(dc))).getId();
-    }
-
-    private Map<String, String> dcQuery(String dc) {
-        return nonNull(dc) ? Map.of("dc", dc): Map.of();
     }
 
     /**

--- a/src/main/java/org/kiwiproject/consul/SessionClient.java
+++ b/src/main/java/org/kiwiproject/consul/SessionClient.java
@@ -1,7 +1,7 @@
 package org.kiwiproject.consul;
 
 import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
+import static org.kiwiproject.consul.ConsulClients.dcQuery;
 
 import org.kiwiproject.consul.config.ClientConfig;
 import org.kiwiproject.consul.model.session.Session;
@@ -64,10 +64,6 @@ public class SessionClient extends BaseClient {
      */
     public SessionCreatedResponse createSession(final Session value, final String dc) {
         return http.extract(api.createSession(value, dcQuery(dc)));
-    }
-
-    private Map<String, String> dcQuery(String dc) {
-        return nonNull(dc) ? Map.of("dc", dc) : Map.of();
     }
 
     public Optional<SessionInfo> renewSession(final String sessionId) {

--- a/src/test/java/org/kiwiproject/consul/ConsulClientsTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulClientsTest.java
@@ -1,0 +1,27 @@
+package org.kiwiproject.consul;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("ConsulClients")
+class ConsulClientsTest {
+
+    @Nested
+    class DcQuery {
+
+        @Test
+        void shouldReturnEmptyMap_WhenGivenBlankString() {
+            assertThat(ConsulClients.dcQuery(null)).isEmpty();
+        }
+
+        @Test
+        void shouldReturnMapContainingSingleDcEntry_WhenGiven() {
+            assertThat(ConsulClients.dcQuery("east"))
+                .containsExactly(entry("dc", "east"));
+        }
+    }
+}


### PR DESCRIPTION
* Add package-private ConsulClients util class
* Move duplicated dcQuery method to ConsulClients
* Replace original dcQuery methods with call to ConsulClients