### PR TITLE
Refactor Optional use in KeyValueClient

### DIFF
--- a/src/main/java/org/kiwiproject/consul/KeyValueClient.java
+++ b/src/main/java/org/kiwiproject/consul/KeyValueClient.java
@@ -177,7 +177,7 @@ public class KeyValueClient extends BaseCacheableClient {
     }
 
     private static <T> ConsulResponse<T> newConsulResponse(T value, ConsulResponse<List<Value>> response) {
-        return new ConsulResponse<T>(value,
+        return new ConsulResponse<>(value,
                 response.getLastContact(),
                 response.isKnownLeader(),
                 response.getIndex(),


### PR DESCRIPTION
* Refactor getConsulResponseWithValue to use functional style instead of conditional with isPresent check.
* Rename getSingleValue to firstValueOrEmpty to more clearly indicate what it actually does.
* Extract common code that constructs a ConsulResponse into private static newConsulResponse method, and call it from the two locations where the ConsulResponse constructor was used in the same way.