### PR TITLE
Fix blacklist expiration behavior in BlacklistingConsulFailoverStrategy

### DIFF
--- a/src/main/java/org/kiwiproject/consul/util/failover/strategy/ConsulFailoverStrategy.java
+++ b/src/main/java/org/kiwiproject/consul/util/failover/strategy/ConsulFailoverStrategy.java
@@ -26,18 +26,18 @@ public interface ConsulFailoverStrategy {
      * (such as when we know with certainty that a host should not be available) without interfering with the consul client too
      * much.
      *
-     * @param current The current inflight request.
+     * @param request The current inflight request.
      * @return A boolean representing if there is another possible request candidate available.
      */
-    boolean isRequestViable(@NonNull Request current);
+    boolean isRequestViable(@NonNull Request request);
 
     /**
      * Marks the specified request as a failed URL (in case of exceptions and other events that could cause
      * us to never get a response). This avoids infinite loops where the strategy can never be made aware that the request
      * has failed.
      *
-     * @param current The current request object representing a request that failed
+     * @param request The request that failed
      */
-    void markRequestFailed(@NonNull Request current);
+    void markRequestFailed(@NonNull Request request);
 
 }

--- a/src/test/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.when;
 import com.google.common.net.HostAndPort;
 import okhttp3.Request;
 import okhttp3.Response;
-
 import org.awaitility.Durations;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -358,7 +357,7 @@ class BlacklistingConsulFailoverStrategyTest {
     }
 
     private void blacklistAll(Collection<HostAndPort> targets) {
-        targets.forEach(strategy::addToBlackist);
+        targets.forEach(strategy::addToBlacklist);
     }
 
     private static void randomlyBlacklistAllButOneTarget(List<HostAndPort> targets,
@@ -369,7 +368,7 @@ class BlacklistingConsulFailoverStrategyTest {
 
         var numToBlacklist = numTargets - 1;
         indices.subList(0, numToBlacklist).forEach(index ->
-                strategy.addToBlackist(targets.get(index)));
+                strategy.addToBlacklist(targets.get(index)));
 
         // guarantee we have one target available
         int numInBlacklist = strategy.blacklist.size();

--- a/src/test/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
@@ -1,134 +1,379 @@
 package org.kiwiproject.consul.util.failover.strategy;
 
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.stream.Collectors.toCollection;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.net.HostAndPort;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 
+import org.awaitility.Durations;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.random.RandomGenerator;
+import java.util.stream.IntStream;
 
+@DisplayName("BlacklistingConsulFailoverStrategy")
 class BlacklistingConsulFailoverStrategyTest {
 
-    private BlacklistingConsulFailoverStrategy blacklistingConsulFailoverStrategy;
+    private BlacklistingConsulFailoverStrategy strategy;
 
-    @BeforeEach
-    void setup() {
-        // Create a set of targets
-        Collection<HostAndPort> targets = new ArrayList<>();
-        targets.add(HostAndPort.fromParts("1.2.3.4", 8501));
-        targets.add(HostAndPort.fromParts("localhost", 8501));
+    @Nested
+    class ComputeNextStage {
 
-        blacklistingConsulFailoverStrategy = new BlacklistingConsulFailoverStrategy(targets, 100_000);
+        @BeforeEach
+        void setUp() {
+            var targets = List.of(
+                HostAndPort.fromParts("1.2.3.4", 8501),
+                HostAndPort.fromParts("localhost", 8501)
+            );
+            var longTimeout = Duration.ofSeconds(100).toMillis();
+
+            strategy = new BlacklistingConsulFailoverStrategy(targets, longTimeout);
+        }
+
+        @Test
+        void getFirstUrlBack() {
+            var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+            Response previousResponse = null;
+
+            // noinspection ConstantValue
+            Optional<Request> result = strategy.computeNextStage(previousRequest, previousResponse);
+
+            assertThat(result).isPresent();
+            assertThat(result.orElseThrow().url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
+        }
+
+        @Test
+        void getSecondUrlBackAfterFirstOneIsBlacklisted() {
+            var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+            Response previousResponse = null;
+
+            // noinspection ConstantValue
+            Optional<Request> result1 = strategy.computeNextStage(previousRequest, previousResponse);
+
+            assertThat(result1).isPresent();
+            assertThat(result1.orElseThrow().url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
+
+            strategy.markRequestFailed(result1.get());
+            // noinspection ConstantValue
+            Optional<Request> result2 = strategy.computeNextStage(result1.get(), previousResponse);
+
+            assertThat(result2).isPresent();
+            assertThat(result2.orElseThrow().url()).hasToString("https://localhost:8501/v1/agent/members");
+        }
+
+        @Test
+        void getNoUrlBackAfterBothAreBlacklisted() {
+            var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+            Response previousResponse = null;
+
+            // noinspection ConstantValue
+            Optional<Request> result1 = strategy.computeNextStage(previousRequest, previousResponse);
+
+            assertThat(result1).isPresent();
+            assertThat(result1.orElseThrow().url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
+
+            strategy.markRequestFailed(result1.get());
+            // noinspection ConstantValue
+            Optional<Request> result2 = strategy.computeNextStage(result1.get(), previousResponse);
+
+            assertThat(result2).isPresent();
+            assertThat(result2.orElseThrow().url()).hasToString("https://localhost:8501/v1/agent/members");
+
+            strategy.markRequestFailed(result2.get());
+
+            // noinspection ConstantValue
+            Optional<Request> result3 = strategy.computeNextStage(result2.get(), previousResponse);
+
+            assertThat(result3).isEmpty();
+        }
+
+        @Test
+        void shouldGetPreviousRequestUrl_WhenPreviousResponseSucceeded() {
+            var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+
+            var previousResponse = mock(Response.class);
+            when(previousResponse.isSuccessful()).thenReturn(true);
+
+            Optional<Request> nextRequestOptional = strategy.computeNextStage(previousRequest, previousResponse);
+
+            assertThat(nextRequestOptional).isPresent();
+
+            var nextRequest = nextRequestOptional.orElseThrow();
+            assertThat(nextRequest.url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
+        }
+
+        @Test
+        void shouldGetPreviousRequestUrl_WhenPreviousResponse_Was_404_NotFound() {
+            var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+
+            var previousResponse = mock(Response.class);
+            when(previousResponse.isSuccessful()).thenReturn(false);
+            when(previousResponse.code()).thenReturn(404);
+
+            Optional<Request> nextRequestOptional = strategy.computeNextStage(previousRequest, previousResponse);
+
+            assertThat(nextRequestOptional).isPresent();
+
+            var nextRequest = nextRequestOptional.orElseThrow();
+            assertThat(nextRequest.url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
+        }
+
+        @Test
+        void shouldGetNextRequestUrl_WhenPreviousResponseFailed() {
+            var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+
+            var previousResponse = mock(Response.class);
+            when(previousResponse.isSuccessful()).thenReturn(false);
+            when(previousResponse.code()).thenReturn(500);
+
+            Optional<Request> nextRequestOptional = strategy.computeNextStage(previousRequest, previousResponse);
+
+            assertThat(nextRequestOptional).isPresent();
+
+            var nextRequest = nextRequestOptional.orElseThrow();
+            assertThat(nextRequest.url()).hasToString("https://localhost:8501/v1/agent/members");
+        }
     }
 
-    @Test
-    void getFirstUrlBack() {
-        var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
-        Response previousResponse = null;
+    @Nested
+    class ComputeNextStageExpiration {
 
-        // noinspection ConstantValue
-        Optional<Request> result = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
+        private List<HostAndPort> targets;
 
-        assertThat(result).isPresent();
-        assertThat(result.orElseThrow().url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
+        @BeforeEach
+        void setUp() {
+            targets = List.of(
+                HostAndPort.fromParts("10.116.84.1", 8501),
+                HostAndPort.fromParts("10.116.84.2", 8501),
+                HostAndPort.fromParts("10.116.84.3", 8501)
+            );
+            var timeoutInMillis = 75;
+
+            strategy = new BlacklistingConsulFailoverStrategy(targets, timeoutInMillis);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 1, 2, 3 })
+        void shouldReturnRequest_WhenNoTargetsAreBlacklisted(int lastOctet) {
+            var url = String.format("https://10.116.84.%d:8501/v1/agent/members", lastOctet);
+            var previousRequest = new Request.Builder().url(url).build();
+            Response previousResponse = null;
+
+            // noinspection ConstantValue
+            Optional<Request> result = strategy.computeNextStage(previousRequest, previousResponse);
+
+            assertThat(result).isPresent();
+            assertThat(result.orElseThrow().url()).hasToString(url);
+
+            assertThat(strategy.blacklist).isEmpty();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 1, 2, 3 })
+        void shouldReturnRequest_WhenAtLeastOneTargetIsAvailable(int lastOctet) {
+            var url = String.format("https://10.116.84.%d:8501/v1/agent/members", lastOctet);
+            var previousRequest = new Request.Builder().url(url).build();
+            Response previousResponse = null;
+
+            randomlyBlacklistAllButOneTarget(targets, strategy);
+
+            // noinspection ConstantValue
+            Optional<Request> result = strategy.computeNextStage(previousRequest, previousResponse);
+
+            assertThat(result).isPresent();
+
+            var nextUrl = result.orElseThrow().url().toString();
+            assertThat(nextUrl).matches("https://10.116.84.[123]:8501/v1/agent/members");
+
+            assertThat(strategy.blacklist).hasSize(targets.size() - 1);
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 1, 2, 3 })
+        void shouldReturnRequest_WhenBlacklistTimeoutExpires(int lastOctet) {
+            var url = String.format("https://10.116.84.%d:8501/v1/agent/members", lastOctet);
+            var previousRequest = new Request.Builder().url(url).build();
+            Response previousResponse = null;
+
+            blacklistAll(targets);
+
+            assertThat(strategy.blacklist).hasSameSizeAs(targets);
+
+            //noinspection ConstantValue
+            await().atMost(Durations.TWO_HUNDRED_MILLISECONDS)
+                    .until(() -> strategy.computeNextStage(previousRequest, previousResponse).isPresent());
+
+            assertThat(strategy.blacklist).hasSizeLessThan(targets.size());
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 1, 2, 3 })
+        void shouldNotReturnRequest_WhenAllTargetsAreBlacklisted(int lastOctet) {
+            var url = String.format("https://10.116.84.%d:8501/v1/agent/members", lastOctet);
+            var previousRequest = new Request.Builder().url(url).build();
+            Response previousResponse = null;
+
+            blacklistAll(targets);
+
+            // noinspection ConstantValue
+            Optional<Request> result = strategy.computeNextStage(previousRequest, previousResponse);
+
+            assertThat(result).isEmpty();
+
+            assertThat(strategy.blacklist).hasSameSizeAs(targets);
+        }
     }
 
-    @Test
-    void getSecondUrlBackAfterFirstOneIsBlacklisted() {
-        var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
-        Response previousResponse = null;
+    @Nested
+    class IsRequestViable {
 
-        // noinspection ConstantValue
-        Optional<Request> result1 = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
+        private List<HostAndPort> targets;
 
-        assertThat(result1).isPresent();
-        assertThat(result1.orElseThrow().url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
+        @BeforeEach
+        void setUp() {
+            targets = List.of(
+                HostAndPort.fromParts("10.116.42.1", 8501),
+                HostAndPort.fromParts("10.116.42.2", 8501),
+                HostAndPort.fromParts("10.116.42.3", 8501)
+            );
+            var timeoutInMillis = 50;
 
-        blacklistingConsulFailoverStrategy.markRequestFailed(result1.get());
-        // noinspection ConstantValue
-        Optional<Request> result2 = blacklistingConsulFailoverStrategy.computeNextStage(result1.get(), previousResponse);
+            strategy = new BlacklistingConsulFailoverStrategy(targets, timeoutInMillis);
+        }
 
-        assertThat(result2).isPresent();
-        assertThat(result2.orElseThrow().url()).hasToString("https://localhost:8501/v1/agent/members");
+        @Test
+        void shouldBeViable_WhenThereAreAvailableTargets() {
+            var request = new Request.Builder().url("https://10.116.42.1:8501/v1/agent/members").build();
+
+            assertThat(strategy.isRequestViable(request)).isTrue();
+
+            assertThat(strategy.blacklist).isEmpty();
+        }
+
+        @Nested
+        class WhenThereAreBlacklistedTargets {
+
+            @RepeatedTest(5)
+            void shouldBeViable_WhenAtLeastOneTargetIsAvailable() {
+                var request = new Request.Builder().url("https://10.116.42.1:8501/v1/agent/members").build();
+
+                randomlyBlacklistAllButOneTarget(targets, strategy);
+
+                assertThat(strategy.isRequestViable(request)).isTrue();
+
+                assertThat(strategy.blacklist).hasSizeLessThan(targets.size());
+            }
+
+            @Test
+            void shouldBeViable_WhenBlacklistTimeoutExpires() {
+                var request = new Request.Builder().url("https://10.116.42.1:8501/v1/agent/members").build();
+
+                blacklistAll(targets);
+
+                await().atMost(Durations.TWO_HUNDRED_MILLISECONDS)
+                        .until(() -> strategy.isRequestViable(request));
+
+                assertThat(strategy.blacklist).hasSizeLessThan(targets.size());
+            }
+
+            @Test
+            void shouldNotBeViable_WhenNoTargetsAreAvailable() {
+                var request = new Request.Builder().url("https://10.116.42.1:8501/v1/agent/members").build();
+
+                blacklistAll(targets);
+
+                assertThat(strategy.isRequestViable(request)).isFalse();
+
+                assertThat(strategy.blacklist).hasSameSizeAs(targets);
+            }
+        }
     }
 
-    @Test
-    void getNoUrlBackAfterBothAreBlacklisted() {
-        var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
-        Response previousResponse = null;
+    @Nested
+    class IsPastBlacklistDuration {
 
-        // noinspection ConstantValue
-        Optional<Request> result1 = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
+        private List<HostAndPort> targets;
 
-        assertThat(result1).isPresent();
-        assertThat(result1.orElseThrow().url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
+        @BeforeEach
+        void setUp() {
+            targets = List.of(
+                HostAndPort.fromParts("10.116.84.1", 8501),
+                HostAndPort.fromParts("10.116.84.2", 8501),
+                HostAndPort.fromParts("10.116.84.3", 8501)
+            );
+        }
 
-        blacklistingConsulFailoverStrategy.markRequestFailed(result1.get());
-        // noinspection ConstantValue
-        Optional<Request> result2 = blacklistingConsulFailoverStrategy.computeNextStage(result1.get(), previousResponse);
+        @RepeatedTest(5)
+        void shouldReturnTrue_WhenTarget_IsNotInBlacklist() {
+            strategy = new BlacklistingConsulFailoverStrategy(targets, 50);
+            var index = RandomGenerator.getDefault().nextInt(0, targets.size());
+            var target = targets.get(index);
 
-        assertThat(result2).isPresent();
-        assertThat(result2.orElseThrow().url()).hasToString("https://localhost:8501/v1/agent/members");
+            assertThat(strategy.isPastBlacklistDuration(target)).isTrue();
+        }
 
-        blacklistingConsulFailoverStrategy.markRequestFailed(result2.get());
+        @RepeatedTest(5)
+        void shouldReturnTrue_WhenBlacklistTimeout_HasExpired() {
+            strategy = new BlacklistingConsulFailoverStrategy(targets, 5);
 
-        // noinspection ConstantValue
-        Optional<Request> result3 = blacklistingConsulFailoverStrategy.computeNextStage(result2.get(), previousResponse);
+            var index = RandomGenerator.getDefault().nextInt(0, targets.size());
+            var target = targets.get(index);
 
-        assertThat(result3).isEmpty();
+            blacklistAll(targets);
+
+            await().pollDelay(Duration.ofMillis(5))
+                    .atMost(Durations.TWO_HUNDRED_MILLISECONDS)
+                    .until(() -> strategy.isPastBlacklistDuration(target));
+        }
+
+        @RepeatedTest(5)
+        void shouldReturnFalse_WhenBlacklistTimeout_HasNotExpired() {
+            strategy = new BlacklistingConsulFailoverStrategy(targets, 500);
+
+            var index = RandomGenerator.getDefault().nextInt(0, targets.size());
+            var target = targets.get(index);
+
+            blacklistAll(targets);
+
+            assertThat(strategy.isPastBlacklistDuration(target)).isFalse();
+        }
     }
 
-    @Test
-    void shouldGetPreviousRequestUrl_WhenPreviousResponseSucceeded() {
-        var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
-
-        var previousResponse = mock(Response.class);
-        when(previousResponse.isSuccessful()).thenReturn(true);
-
-        Optional<Request> nextRequestOptional = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
-
-        assertThat(nextRequestOptional).isPresent();
-
-        var nextRequest = nextRequestOptional.orElseThrow();
-        assertThat(nextRequest.url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
+    private void blacklistAll(Collection<HostAndPort> targets) {
+        targets.forEach(strategy::addToBlackist);
     }
 
-    @Test
-    void shouldGetPreviousRequestUrl_WhenPreviousResponse_Was_404_NotFound() {
-        var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
+    private static void randomlyBlacklistAllButOneTarget(List<HostAndPort> targets,
+                                                         BlacklistingConsulFailoverStrategy strategy) {
+        var numTargets = targets.size();
+        var indices = IntStream.range(0, numTargets).boxed().collect(toCollection(ArrayList::new));
+        Collections.shuffle(indices);
 
-        var previousResponse = mock(Response.class);
-        when(previousResponse.isSuccessful()).thenReturn(false);
-        when(previousResponse.code()).thenReturn(404);
+        var numToBlacklist = numTargets - 1;
+        indices.subList(0, numToBlacklist).forEach(index ->
+                strategy.addToBlackist(targets.get(index)));
 
-        Optional<Request> nextRequestOptional = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
-
-        assertThat(nextRequestOptional).isPresent();
-
-        var nextRequest = nextRequestOptional.orElseThrow();
-        assertThat(nextRequest.url()).hasToString("https://1.2.3.4:8501/v1/agent/members");
-    }
-
-    @Test
-    void shouldGetNextRequestUrl_WhenPreviousResponseFailed() {
-        var previousRequest = new Request.Builder().url("https://1.2.3.4:8501/v1/agent/members").build();
-
-        var previousResponse = mock(Response.class);
-        when(previousResponse.isSuccessful()).thenReturn(false);
-        when(previousResponse.code()).thenReturn(500);
-
-        Optional<Request> nextRequestOptional = blacklistingConsulFailoverStrategy.computeNextStage(previousRequest, previousResponse);
-
-        assertThat(nextRequestOptional).isPresent();
-
-        var nextRequest = nextRequestOptional.orElseThrow();
-        assertThat(nextRequest.url()).hasToString("https://localhost:8501/v1/agent/members");
+        // guarantee we have one target available
+        int numInBlacklist = strategy.blacklist.size();
+        checkState(numInBlacklist == numToBlacklist,
+                "expected %s in blacklist, but found %s", numToBlacklist, numInBlacklist);
     }
 }


### PR DESCRIPTION
* Factor duplicate logic from if and else branches in computeNextStage.
* Extract blacklist expiration duration logic from findTargetNotInBlacklist to new method isPastBlacklistDuration.
* Change isRequestViable to call findTargetNotInBlacklist. Because findTargetNotInBlacklist will remove a target from the blacklist if past the expiration, this now ensures a correct result. If the target is not blacklisted, then the request is viable. If it or any other target is blacklisted but past the expiration, that target is considered viable and removed from the blacklist. Only if all targets are currently in blacklist and none have expired is the request considered not viable.
* Create addToBlacklist method to replace duplicate blacklist.put calls.
* Create isBlacklisted method to check if a target is in blacklist.
* Create isNotBlacklisted method to check if a target is not in blacklist.
* Rename fromRequest to hostAndPortFromRequest for clarity.
* Rename the blacklistingConsulFailoverStrategy field in the test to just "strategy" since it is much shorter, and because the test is only related to the BlacklistingConsulFailoverStrategy.
* Rename the "current" parameter in ConsulFailoverStrategy methods to "request"
* Add more tests. Move the original tests inside a nested class ComputeNextStage. The new tests are nested inside their own nested classes for the various scenarios. I kept the tests for blacklsit expiration for computeNextStage in a separate nested class, ComputeNextStageExpiration, mainly b/c they are new and are specifically for testing the expiration logic. Also added dedicated tests for isRequest and the (internal) isPastBlacklistDuration method.

Fixes #388