### PR TITLE
Use a parameterized log message in TimeoutInterceptor

### DIFF
--- a/src/main/java/org/kiwiproject/consul/cache/TimeoutInterceptor.java
+++ b/src/main/java/org/kiwiproject/consul/cache/TimeoutInterceptor.java
@@ -73,7 +73,7 @@ public class TimeoutInterceptor implements Interceptor {
                 wait = Duration.ofSeconds(Long.parseLong(query.replace("s","")));
             }
         } catch (Exception e) {
-            LOG.warn(String.format("Error while extracting wait duration from query parameters: %s", query));
+            LOG.warn("Error while extracting wait duration from query parameters: {}", query);
         }
         return wait;
     }


### PR DESCRIPTION
* Replace String#format inside a Logger#warn statement with a parameterized log message.

Closes #391