### PR TITLE
Deprecate original ConsulFailoverStrategy#computeNextStage for removal

### DIFF
--- a/src/main/java/org/kiwiproject/consul/util/failover/ConsulFailoverInterceptor.java
+++ b/src/main/java/org/kiwiproject/consul/util/failover/ConsulFailoverInterceptor.java
@@ -82,6 +82,7 @@ public class ConsulFailoverInterceptor implements Interceptor {
         return maxFailoverAttempts;
     }
 
+    @SuppressWarnings("removal")
     @NonNull
     @Override
     public Response intercept(Chain chain) {

--- a/src/main/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
+++ b/src/main/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
@@ -57,6 +57,7 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
         return computeNextStage(previousRequest, null);
     }
 
+    @SuppressWarnings("removal")
     @NonNull
     @Override
     public Optional<Request> computeNextStage(@NonNull Request previousRequest, @Nullable Response previousResponse) {

--- a/src/main/java/org/kiwiproject/consul/util/failover/strategy/ConsulFailoverStrategy.java
+++ b/src/main/java/org/kiwiproject/consul/util/failover/strategy/ConsulFailoverStrategy.java
@@ -26,7 +26,10 @@ public interface ConsulFailoverStrategy {
      * @param previousRequest  The last request to go out the door.
      * @param previousResponse The response that was returned when the previousRequest was completed.
      * @return An optional failover request. This may return an empty optional, signaling that the request should be aborted
+     * @deprecated for removal in 2.0.0, replaced by {@link #computeNextStage(Request)}
      */
+    @Deprecated(since = "1.5.0", forRemoval = true)
+    @SuppressWarnings({ "java:S1133", "DeprecatedIsStillUsed" })
     @NonNull
     Optional<Request> computeNextStage(@NonNull Request previousRequest, @Nullable Response previousResponse);
 

--- a/src/test/java/org/kiwiproject/consul/util/failover/ConsulFailoverInterceptorTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/failover/ConsulFailoverInterceptorTest.java
@@ -72,6 +72,7 @@ class ConsulFailoverInterceptorTest {
         verify(strategy, only()).isRequestViable(any(Request.class));
     }
 
+    @SuppressWarnings("removal")
     @Test
     void shouldThrowException_WhenNextStageIsEmpty() {
         when(strategy.isRequestViable(any(Request.class))).thenReturn(true);
@@ -88,6 +89,7 @@ class ConsulFailoverInterceptorTest {
         verifyNoMoreInteractions(strategy);
     }
 
+    @SuppressWarnings("removal")
     @Test
     void shouldReturnResponse_WhenGetResponse_BeforeExceedingMaxFailoverAttempts() throws IOException {
         when(strategy.isRequestViable(any(Request.class))).thenReturn(true);
@@ -115,6 +117,7 @@ class ConsulFailoverInterceptorTest {
         verify(chain, times(3)).proceed(any(Request.class));
     }
 
+    @SuppressWarnings("removal")
     @Test
     void shouldThrowException_WhenMaxFailoverAttemptsExceeded() throws IOException {
         when(strategy.isRequestViable(any(Request.class))).thenReturn(true);


### PR DESCRIPTION
* Deprecate ConsulFailoverStrategy#computeNextStage(Request, Response) for removal in 2.0.0.
* Suppress the deprecation warnings, since the deprecated method is scheduled for removal.

Closes #394