### PR TITLE
Extract HostAndPorts utility class

### DIFF
--- a/src/main/java/org/kiwiproject/consul/util/HostAndPorts.java
+++ b/src/main/java/org/kiwiproject/consul/util/HostAndPorts.java
@@ -1,0 +1,26 @@
+package org.kiwiproject.consul.util;
+
+import com.google.common.net.HostAndPort;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+
+/**
+ * Utilities related to {@link HostAndPort}.
+ */
+public class HostAndPorts {
+
+    private HostAndPorts() {
+        // utility class
+    }
+
+    /**
+     * Create a new {@link HostAndPort} instance from the given OkHttp {@link Request}.
+     *
+     * @param request the OkHttp request
+     * @return a new {@link HostAndPort} instance
+     */
+    public static HostAndPort hostAndPortFromOkHttpRequest(Request request) {
+        HttpUrl url = request.url();
+        return HostAndPort.fromParts(url.host(), url.port());
+    }
+}

--- a/src/test/java/org/kiwiproject/consul/util/HostAndPortsTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/HostAndPortsTest.java
@@ -1,0 +1,45 @@
+package org.kiwiproject.consul.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+@DisplayName("HostAndPorts")
+class HostAndPortsTest {
+
+    @Nested
+    class HostAndPortFromOkHttpRequest {
+
+        @ParameterizedTest
+        @CsvSource(textBlock = """
+                http,  10.116.84.1,       8501
+                https, 10.116.84.2,       8501
+                http,  consul-1.acme.com, 8500
+                https, consul-2.acme.com, 8500
+                """)
+        void shouldCreateNewInstance(String scheme, String host, int port) {
+            var httpUrl = new HttpUrl.Builder()
+                    .scheme(scheme)
+                    .host(host)
+                    .port(port)
+                    .build();
+            var request = mock(Request.class);
+            when(request.url()).thenReturn(httpUrl);
+
+            var hostAndPort = HostAndPorts.hostAndPortFromOkHttpRequest(request);
+
+            assertAll(
+                    () -> assertThat(hostAndPort.getHost()).isEqualTo(host),
+                    () -> assertThat(hostAndPort.getPort()).isEqualTo(port)
+            );
+        }
+    }
+}


### PR DESCRIPTION
* This class contains one method to create a new HostAndPorts instance from an OkHttp Request object.
* Refactor BlacklistingConsulFailoverStrategy to use this method and remove the unused #hostAndPortFromRequest method.
* This new utility will be used in the new round-robin ConsulFailoverStrategy implementation.

Relates to #397