### PR TITLE
Add isNotNullOrEmpty to Lists

### DIFF
--- a/src/main/java/org/kiwiproject/consul/util/Lists.java
+++ b/src/main/java/org/kiwiproject/consul/util/Lists.java
@@ -5,6 +5,9 @@ import static java.util.Objects.isNull;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Static utilities related to {@link List}.
+ */
 public class Lists {
 
     private Lists() {
@@ -13,6 +16,10 @@ public class Lists {
 
     public static <T> Optional<T> firstValueOrEmpty(List<T> list) {
         return isNullOrEmpty(list) ? Optional.empty() : Optional.of(list.get(0));
+    }
+
+    public static <T> boolean isNotNullOrEmpty(List<T> list) {
+        return !isNullOrEmpty(list);
     }
 
     public static <T> boolean isNullOrEmpty(List<T> list) {

--- a/src/test/java/org/kiwiproject/consul/util/ListsTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/ListsTest.java
@@ -53,4 +53,21 @@ class ListsTest {
             assertThat(Lists.isNullOrEmpty(list)).isFalse();
         }
     }
+
+    @Nested
+    class IsNotNullOrEmpty {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldReturnFalse_WhenListIsNullOrEmpty(List<String> list) {
+            assertThat(Lists.isNotNullOrEmpty(list)).isFalse();
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 1, 2, 3 })
+        void shouldReturnTrue_WhenListIsNotEmpty(int size) {
+            List<Integer> list = Collections.nCopies(size, 42);
+            assertThat(Lists.isNotNullOrEmpty(list)).isTrue();
+        }
+    }
 }


### PR DESCRIPTION
Maybe we need to start depending on our own kiwi project, since it already has a lot of the utilities we need, such as this one.

This method is going to be used in the round-robin ConsulFailoverStrategy implementation.

Relates to #397