### PR TITLE
Validate targets argument in BlacklistingConsulFailoverStrategy ctor

### DIFF
--- a/src/main/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
+++ b/src/main/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategy.java
@@ -29,11 +29,11 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
     @VisibleForTesting
     final Map<HostAndPort, Instant> blacklist = new ConcurrentHashMap<>();
 
-    // The map of viable targets
-    private final Collection<HostAndPort> targets;
+    // The list of viable targets
+    private final List<HostAndPort> targets;
     private final int numberOfTargets;
 
-    // The blacklist timeout
+    // The blacklist timeout (in milliseconds)
     private final long timeout;
 
     /**
@@ -46,8 +46,10 @@ public class BlacklistingConsulFailoverStrategy implements ConsulFailoverStrateg
      * @param timeout The timeout in milliseconds
      */
     public BlacklistingConsulFailoverStrategy(Collection<HostAndPort> targets, long timeout) {
+        checkArgument(nonNull(targets) && !targets.isEmpty(), "targets must not be null or empty");
         this.targets = List.copyOf(targets);
         this.numberOfTargets = this.targets.size();
+        
         checkArgument(timeout > 0, "timeout must be a positive number of milliseconds");
         this.timeout = timeout;
     }

--- a/src/test/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/failover/strategy/BlacklistingConsulFailoverStrategyTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
@@ -35,6 +36,14 @@ import java.util.stream.Stream;
 class BlacklistingConsulFailoverStrategyTest {
 
     private BlacklistingConsulFailoverStrategy strategy;
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    void shouldRequireNonEmptyTargetsCollection(Collection<HostAndPort> targets) {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new BlacklistingConsulFailoverStrategy(targets, 25))
+                .withMessage("targets must not be null or empty");
+    }
 
     @ParameterizedTest
     @MethodSource("invalidTimeouts")


### PR DESCRIPTION
* Validate the 'targets' argument is not null or empty.
* Change the 'targets' field type to List<HostAndPort> since we do a List.copyOf in the constructor.