### PR TITLE
Add round-robin implementation of ConsulFailoverStrategy

### DIFF
--- a/src/main/java/org/kiwiproject/consul/util/failover/strategy/ConsulFailoverStrategy.java
+++ b/src/main/java/org/kiwiproject/consul/util/failover/strategy/ConsulFailoverStrategy.java
@@ -7,6 +7,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import java.util.Optional;
 
+/**
+ * Defines a contract for selecting a Consul failover server when a request fails.
+ * <p>
+ * Implementations of this interface are used by
+ * {@link org.kiwiproject.consul.util.failover.ConsulFailoverInterceptor ConsulFailoverInterceptor}.
+ */
 public interface ConsulFailoverStrategy {
 
     /**
@@ -52,4 +58,16 @@ public interface ConsulFailoverStrategy {
      */
     void markRequestFailed(@NonNull Request request);
 
+    /**
+     * Reset the state when all options are exhausted (if needed).
+     * <p>
+     * Use this in implementations that need to keep internal state
+     * during a failover attempt. If the implementation is stateless,
+     * then there is no need to implement this method.
+     * <p>
+     * The default implementation does nothing.
+     */
+    default void reset() {
+        // no-op
+    }
 }

--- a/src/main/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategy.java
+++ b/src/main/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategy.java
@@ -1,0 +1,116 @@
+package org.kiwiproject.consul.util.failover.strategy;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.nonNull;
+import static org.apache.commons.lang3.ThreadUtils.sleepQuietly;
+import static org.kiwiproject.consul.util.HostAndPorts.hostAndPortFromOkHttpRequest;
+import static org.kiwiproject.consul.util.Lists.isNotNullOrEmpty;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.net.HostAndPort;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A {@link ConsulFailoverStrategy} that round-robins a list of Consul servers.
+ */
+public class RoundRobinConsulFailoverStrategy implements ConsulFailoverStrategy {
+
+    // set to invalid index for initial state, so that we always try the first target initially
+    @VisibleForTesting
+    final AtomicInteger lastTargetIndex = new AtomicInteger(-1);
+
+    private final List<HostAndPort> targets;
+    private final int numberOfTargets;
+    private final Duration delay;
+    private final boolean delayAfterFailedRequest;
+
+    /**
+     * Create a new instance with the given list of Consul target servers.
+     *
+     * @param targets the Consul servers
+     */
+    public RoundRobinConsulFailoverStrategy(List<HostAndPort> targets) {
+        this(targets, Duration.ZERO);
+    }
+
+    /**
+     * Create a new instance with the given list of Consul target servers.
+     * <p>
+     * After each failed request, the instance will sleep for the given delay.
+     *
+     * @param targets           the Consul servers
+     * @param delayAfterFailure the amount to sleep after a failed request
+     */
+    public RoundRobinConsulFailoverStrategy(List<HostAndPort> targets, Duration delayAfterFailure) {
+        checkArgument(isNotNullOrEmpty(targets), "targets must not be null or empty");
+        this.targets = List.copyOf(targets);
+        this.numberOfTargets = targets.size();
+
+        checkArgument(nonNull(delayAfterFailure), "delayAfterFailure must not be null");
+        var millis = delayAfterFailure.toMillis();
+        checkArgument(millis >= 0, "delayAfterFailure must be zero or a positive duration");
+        this.delay = delayAfterFailure;
+        this.delayAfterFailedRequest = millis > 0;
+    }
+
+    @Override
+    @NonNull
+    public Optional<Request> computeNextStage(Request previousRequest) {
+        return computeNextStage(previousRequest, null);
+    }
+
+    @SuppressWarnings("removal")
+    @Override
+    @NonNull
+    public Optional<Request> computeNextStage(@NonNull Request previousRequest, @Nullable Response previousResponse) {
+        var nextTarget = hostAndPortFromOkHttpRequest(previousRequest);
+        var indexOfNextTarget = targets.indexOf(nextTarget);
+
+        if (lastTargetIndex.get() == indexOfNextTarget) {
+            var nextIndex = nextCircularListIndex(indexOfNextTarget);
+
+            lastTargetIndex.set(nextIndex);
+
+            nextTarget = targets.get(nextIndex);
+
+            sleepIfPositiveDelay();
+        }
+
+        HttpUrl nextURL = previousRequest.url().newBuilder()
+                .host(nextTarget.getHost())
+                .port(nextTarget.getPort())
+                .build();
+        return Optional.of(previousRequest.newBuilder().url(nextURL).build());
+    }
+
+    private int nextCircularListIndex(int currentIndex) {
+        return (currentIndex + 1) % numberOfTargets;
+    }
+
+    private void sleepIfPositiveDelay() {
+        if (delayAfterFailedRequest) {
+            sleepQuietly(delay);
+        }
+    }
+
+    @Override
+    public boolean isRequestViable(@NonNull Request request) {
+        // always viable since we will move to the next target after a failure
+        return true;
+    }
+
+    @Override
+    public void markRequestFailed(@NonNull Request request) {
+        var hostAndPort = hostAndPortFromOkHttpRequest(request);
+        lastTargetIndex.set(targets.indexOf(hostAndPort));
+    }
+}

--- a/src/main/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategy.java
+++ b/src/main/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategy.java
@@ -3,7 +3,6 @@ package org.kiwiproject.consul.util.failover.strategy;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.nonNull;
 import static org.apache.commons.lang3.ThreadUtils.sleepQuietly;
-import static org.kiwiproject.consul.util.HostAndPorts.hostAndPortFromOkHttpRequest;
 import static org.kiwiproject.consul.util.Lists.isNotNullOrEmpty;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -52,7 +51,7 @@ public class RoundRobinConsulFailoverStrategy implements ConsulFailoverStrategy 
     public RoundRobinConsulFailoverStrategy(List<HostAndPort> targets, Duration delayAfterFailure) {
         checkArgument(isNotNullOrEmpty(targets), "targets must not be null or empty");
         this.targets = List.copyOf(targets);
-        this.numberOfTargets = targets.size();
+        this.numberOfTargets = this.targets.size();
 
         checkArgument(nonNull(delayAfterFailure), "delayAfterFailure must not be null");
         var millis = delayAfterFailure.toMillis();
@@ -103,8 +102,7 @@ public class RoundRobinConsulFailoverStrategy implements ConsulFailoverStrategy 
 
     @Override
     public void markRequestFailed(@NonNull Request request) {
-        var hostAndPort = hostAndPortFromOkHttpRequest(request);
-        lastTargetIndexThreadLocal.set(targets.indexOf(hostAndPort));
+        lastTargetIndexThreadLocal.set(lastTargetIndexThreadLocal.get() + 1);
     }
 
     @Override

--- a/src/test/java/org/kiwiproject/consul/util/failover/ConsulFailoverInterceptorTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/failover/ConsulFailoverInterceptorTest.java
@@ -6,7 +6,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -68,7 +67,9 @@ class ConsulFailoverInterceptorTest {
         // noinspection resource
         assertThatExceptionOfType(ConsulException.class).isThrownBy(() -> interceptor.intercept(chain));
 
-        verify(strategy, only()).isRequestViable(any(Request.class));
+        verify(strategy).isRequestViable(any(Request.class));
+        verify(strategy).reset();
+        verifyNoMoreInteractions(strategy);
     }
 
     @Test
@@ -83,6 +84,7 @@ class ConsulFailoverInterceptorTest {
 
         verify(strategy).isRequestViable(any(Request.class));
         verify(strategy).computeNextStage(any(Request.class));
+        verify(strategy).reset();
         verifyNoMoreInteractions(strategy);
     }
 

--- a/src/test/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategyTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategyTest.java
@@ -195,6 +195,23 @@ class RoundRobinConsulFailoverStrategyTest {
         }
     }
 
+    @Nested
+    class Reset {
+
+        @Test
+        void shouldResetLastTargetIndex() {
+            var request = newRequest("https://10.116.42.1:8501/v1/agent/members");
+
+            strategy.markRequestFailed(request);
+
+            assertThat(strategy.lastTargetIndexThreadLocal.get()).isZero();
+
+            strategy.reset();
+
+            assertThat(strategy.lastTargetIndexThreadLocal.get()).isEqualTo(-1);
+        }
+    }
+
     private static Request newMembersRequest(HostAndPort target) {
         var url = membersUrl(target);
         return newRequest(url);

--- a/src/test/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategyTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategyTest.java
@@ -202,7 +202,7 @@ class RoundRobinConsulFailoverStrategyTest {
 
             strategy.markRequestFailed(request);
 
-            assertThat(strategy.lastTargetIndex).hasValue(index);
+            assertThat(strategy.lastTargetIndexThreadLocal.get()).hasValue(index);
         }
     }
 

--- a/src/test/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategyTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategyTest.java
@@ -185,9 +185,11 @@ class RoundRobinConsulFailoverStrategyTest {
 
         @ParameterizedTest
         @ValueSource(ints = { 0, 1, 2 })
-        void shouldSetLastTargetIndex_ToIndexOfHostAndPortFromRequest(int index) {
+        void shouldSetLastTargetIndex_ToNextIndex(int index) {
             var target = targets.get(index);
             var request = newMembersRequest(target);
+
+            strategy.lastTargetIndexThreadLocal.set(index - 1);
 
             strategy.markRequestFailed(request);
 

--- a/src/test/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategyTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/failover/strategy/RoundRobinConsulFailoverStrategyTest.java
@@ -1,0 +1,240 @@
+package org.kiwiproject.consul.util.failover.strategy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.google.common.net.HostAndPort;
+import okhttp3.Request;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@DisplayName("RoundRobinConsulFailoverStrategy")
+class RoundRobinConsulFailoverStrategyTest {
+
+    private List<HostAndPort> targets;
+    private RoundRobinConsulFailoverStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        targets = List.of(
+                HostAndPort.fromParts("10.116.42.1", 8501),
+                HostAndPort.fromParts("10.116.42.2", 8501),
+                HostAndPort.fromParts("10.116.42.3", 8501)
+        );
+
+        strategy = new RoundRobinConsulFailoverStrategy(targets);
+    }
+
+    @Nested
+    class Constructors {
+
+        @ParameterizedTest
+        @NullAndEmptySource
+        void shouldRequireNonEmptyTargetsCollection(List<HostAndPort> invalidTargets) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new RoundRobinConsulFailoverStrategy(invalidTargets))
+                    .withMessage("targets must not be null or empty");
+        }
+
+        @Test
+        void shouldRequireNonNullDelayDuration() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new RoundRobinConsulFailoverStrategy(targets, null))
+                    .withMessage("delayAfterFailure must not be null");
+        }
+
+        @ParameterizedTest
+        @ValueSource(longs = { -1000, -10, -5, -2, -1 })
+        void shouldRequireZeroOrPositiveDelay(long delayMillis) {
+            var delay = Duration.ofMillis(delayMillis);
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> new RoundRobinConsulFailoverStrategy(targets, delay))
+                    .withMessage("delayAfterFailure must be zero or a positive duration");
+        }
+    }
+
+    @Nested
+    class ComputeNextStage {
+
+        @Test
+        void shouldReturnFirstTarget_IfRequestSucceeds() {
+            var request = newRequest("https://10.116.42.1:8501/v1/agent/members");
+
+            var nextRequestHttpUrl = strategy.computeNextStage(request)
+                    .map(Request::url)
+                    .orElseThrow();
+
+            assertThat(nextRequestHttpUrl).isEqualTo(request.url());
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, 1, 2 })
+        void shouldReturnSameTarget_IfRequestSucceeds(int index) {
+            var target = targets.get(index);
+            var request = newMembersRequest(target);
+
+            var nextRequestHttpUrl = strategy.computeNextStage(request)
+                    .map(Request::url)
+                    .orElseThrow();
+
+            assertThat(nextRequestHttpUrl).isEqualTo(request.url());
+        }
+
+        @Test
+        void shouldReturnSecondTarget_IfFirstRequestFails() {
+            var request = newRequest("https://10.116.42.1:8501/v1/agent/members");
+
+            strategy.markRequestFailed(request);
+
+            var nextRequestHttpUrl = strategy.computeNextStage(request)
+                    .map(Request::url)
+                    .orElseThrow();
+
+            assertThat(nextRequestHttpUrl.url())
+                    .hasToString("https://10.116.42.2:8501/v1/agent/members");
+        }
+
+        @Test
+        void shouldReturnExpectedTarget_AfterRequestFailure_AndWrapAroundToFirstTarget() {
+            var request1 = newRequest("https://10.116.42.1:8501/v1/agent/members");
+
+            // need to mark initial request as failed (but not on later calls
+            // because computeNextStage advances the index when needed)
+            strategy.markRequestFailed(request1);
+
+            var request2 = strategy.computeNextStage(request1).orElseThrow();
+            assertThat(request2.url())
+                    .hasToString("https://10.116.42.2:8501/v1/agent/members");
+
+            var request3 = strategy.computeNextStage(request2).orElseThrow();
+            assertThat(request3.url())
+                    .hasToString("https://10.116.42.3:8501/v1/agent/members");
+
+            var request4 = strategy.computeNextStage(request3).orElseThrow();
+            assertThat(request4.url())
+                    .hasToString("https://10.116.42.1:8501/v1/agent/members");
+
+            var request5 = strategy.computeNextStage(request4).orElseThrow();
+            assertThat(request5.url())
+                    .hasToString("https://10.116.42.2:8501/v1/agent/members");
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, 1, 2 })
+        void shouldReturnExpectedNextTarget(int index) {
+            var target = targets.get(index);
+            var request = newMembersRequest(target);
+
+            strategy.markRequestFailed(request);
+
+            var nextRequest = strategy.computeNextStage(request).orElseThrow();
+
+            var nextIndex = (index == 2) ? 0 : index + 1;
+            var nextTarget = targets.get(nextIndex);
+            var expectedNextUrl = membersUrl(nextTarget);
+            assertThat(nextRequest.url()).hasToString(expectedNextUrl);
+        }
+
+        @Nested
+        class WithDelayAfterFailure {
+
+            private int delayMillis;
+
+            @BeforeEach
+            void setUp() {
+                delayMillis = 25;
+                strategy = new RoundRobinConsulFailoverStrategy(targets, Duration.ofMillis(delayMillis));
+            }
+
+            @Test
+            void shouldNotSleep_IfRequestSucceeds() {
+                var request = newRequest("https://10.116.42.1:8501/v1/agent/members");
+
+                var elapsedMillis = timeComputeNextStage(request);
+                assertThat(elapsedMillis).isLessThan(delayMillis);
+            }
+
+            @Test
+            void shouldSleep_ExpectedTime_IfRequestFails() {
+                var request = newRequest("https://10.116.42.1:8501/v1/agent/members");
+                strategy.markRequestFailed(request);
+
+                var elapsedMillis = timeComputeNextStage(request);
+                assertThat(elapsedMillis).isGreaterThanOrEqualTo(delayMillis);
+            }
+
+            private long timeComputeNextStage(Request request) {
+                var start = System.nanoTime();
+                strategy.computeNextStage(request);
+                var elapsed = System.nanoTime() - start;
+                return TimeUnit.NANOSECONDS.toMillis(elapsed);
+            }
+        }
+    }
+
+    @Nested
+    class IsRequestViable {
+
+        @ParameterizedTest
+        @ValueSource(strings = {
+                "https://10.116.42.1:8501/v1/agent/members",
+                "https://10.116.42.2:8501/v1/agent/members",
+                "https://10.116.42.3:8501/v1/agent/members"
+        })
+        void shouldReturnTrueFromIsRequestViable(String url) {
+            var request = newRequest(url);
+            assertThat(strategy.isRequestViable(request)).isTrue();
+        }
+
+        @Test
+        void shouldAlwaysReturnTrue() {
+            int numTimesThroughAllTargets = 10;
+            var urlTemplate = "https://10.116.42.%d:8501/v1/agent/members";
+
+            for (var i = 0; i < numTimesThroughAllTargets; i++) {
+                for (var lastOctet = 1; lastOctet <= 3; lastOctet++) {
+                    var url = String.format(urlTemplate, lastOctet);
+                    var request = newRequest(url);
+                    assertThat(strategy.isRequestViable(request)).isTrue();
+                }
+            }
+        }
+    }
+
+    @Nested
+    class MarkRequestFailed {
+
+        @ParameterizedTest
+        @ValueSource(ints = { 0, 1, 2 })
+        void shouldSetLastTargetIndex_ToIndexOfHostAndPortFromRequest(int index) {
+            var target = targets.get(index);
+            var request = newMembersRequest(target);
+
+            strategy.markRequestFailed(request);
+
+            assertThat(strategy.lastTargetIndex).hasValue(index);
+        }
+    }
+
+    private static Request newMembersRequest(HostAndPort target) {
+        var url = membersUrl(target);
+        return newRequest(url);
+    }
+
+    private static String membersUrl(HostAndPort target) {
+        return String.format("https://%s:8501/v1/agent/members", target.getHost());
+    }
+
+    private static Request newRequest(String url) {
+        return new Request.Builder().url(url).build();
+    }
+}


### PR DESCRIPTION
* Add a new "reset" method to ConsulFailoverStrategy to allow for stateful implementations.
* Update ConsulFailoverInterceptor to call the ConsulFailoverStrategy#reset method in a
  finally block.
* Add RoundRobinConsulFailoverStrategy with optional delay after failed requests. 
  It just keeps picking the next target server until all have failed, and then returns
  an empty Request to indicate that the failover should halt.

Closes #397