### PR TITLE
OkHttp 5 preparation: Remove verifyNoMoreInteractions from LifecycleITest

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/LifecycleITest.java
+++ b/src/itest/java/org/kiwiproject/consul/LifecycleITest.java
@@ -2,8 +2,8 @@ package org.kiwiproject.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import okhttp3.ConnectionPool;
 import okhttp3.internal.Util;
@@ -32,7 +32,7 @@ class LifecycleITest extends BaseIntegrationTest {
 
     @Test
     void shouldDestroyTheExecutorServiceWhenDestroyMethodIsInvoked() {
-        var connectionPool = new ConnectionPool();
+        var connectionPool = spy(new ConnectionPool());
         var executorService = mock(ExecutorService.class);
 
         Consul client = Consul.builder()
@@ -45,7 +45,7 @@ class LifecycleITest extends BaseIntegrationTest {
 
         assertThat(client.isDestroyed()).isTrue();
         verify(executorService).shutdownNow();
-        verifyNoMoreInteractions(executorService);
+        verify(connectionPool).evictAll();
     }
 
     @Test


### PR DESCRIPTION
In shouldDestroyTheExecutorServiceWhenDestroyMethodIsInvoked:

* Remove verifyNoMoreInteractions so we only verify our own code's behavior
* Spy the ConnectionPool and verify the call to evictAll

We can't (easily) verify that the we got the OkHttpClient Dispatcher and called cancelAll().
This is because the OkHttpClient is created internally within Consul, and so without changing
internals, we can't mock it or spy it easily.

Closes #437