### PR TITLE
ConsulException deprecations, new constructor, and message improvements

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/AgentClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/AgentClientITest.java
@@ -71,7 +71,7 @@ class AgentClientITest extends BaseIntegrationTest {
 
         assertThatExceptionOfType(ConsulException.class)
                 .isThrownBy(expectToFailAgentClient::ping)
-                .withMessage("Error connecting to Consul")
+                .withMessage("Error connecting to Consul agent")
                 .withCauseExactlyInstanceOf(ConnectException.class);
     }
 

--- a/src/itest/java/org/kiwiproject/consul/failover/FailoverTest.java
+++ b/src/itest/java/org/kiwiproject/consul/failover/FailoverTest.java
@@ -75,7 +75,7 @@ class FailoverTest extends BaseIntegrationTest {
 
         assertThatExceptionOfType(ConsulException.class)
                 .isThrownBy(consulBuilder::build)
-                .withMessage("Error connecting to Consul")
+                .withMessage("Error connecting to Consul agent")
                 .havingCause()
                 .isExactlyInstanceOf(MaxFailoverAttemptsExceededException.class)
                 .withCauseInstanceOf(SocketTimeoutException.class);

--- a/src/main/java/org/kiwiproject/consul/AgentClient.java
+++ b/src/main/java/org/kiwiproject/consul/AgentClient.java
@@ -75,11 +75,11 @@ public class AgentClient extends BaseClient {
             retrofit2.Response<Void> response = api.ping().execute();
 
             if (!response.isSuccessful()) {
-                throw new ConsulException(String.format("Error pinging Consul: %s",
+                throw new ConsulException(String.format("Error pinging Consul agent: %s",
                         response.message()));
             }
         } catch (Exception ex) {
-            throw new ConsulException("Error connecting to Consul", ex);
+            throw new ConsulException("Error connecting to Consul agent", ex);
         }
     }
 

--- a/src/main/java/org/kiwiproject/consul/ConsulException.java
+++ b/src/main/java/org/kiwiproject/consul/ConsulException.java
@@ -1,8 +1,10 @@
 package org.kiwiproject.consul;
 
 import static java.util.Objects.isNull;
+import static org.kiwiproject.consul.util.Http.requestUrlOf;
 
 import okhttp3.ResponseBody;
+import retrofit2.Call;
 import retrofit2.Response;
 
 import java.io.IOException;
@@ -38,6 +40,12 @@ public class ConsulException extends RuntimeException {
         this.hasCode = false;
     }
 
+    /**
+     * Constructs an instance for the given status code and Retrofit {@link Response}.
+     * 
+     * @deprecated use {@link #ConsulException(Call, Response)}
+     */
+    @Deprecated(since = "1.7.0", forRemoval = true)
     public ConsulException(int code, Response<?> response) {
         super(String.format("Consul request failed with status [%s]: %s",
                 code, message(response)));
@@ -45,6 +53,24 @@ public class ConsulException extends RuntimeException {
         this.hasCode = true;
     }
 
+    /**
+     * Constructs an instance from the given Retrofit {@link Call} and corresponding {@link Response}.
+     * 
+     * @param call the {@link Call} that initiated the request
+     * @param response the {@link Response}
+     */
+    public ConsulException(Call<?> call, Response<?> response) {
+        super(String.format("Consul request to [%s] failed with status [%s]: %s",
+                requestUrlOf(call), response.code(), message(response)));
+        this.code = response.code();
+        this.hasCode = true;
+    }
+
+    /**
+     * Constructs an instance for the given {@link Throwable}.
+     * 
+     * @param throwable the cause
+     */
     public ConsulException(Throwable throwable) {
         super("Consul request failed", throwable);
         this.code = 0;

--- a/src/main/java/org/kiwiproject/consul/KeyValueClient.java
+++ b/src/main/java/org/kiwiproject/consul/KeyValueClient.java
@@ -632,7 +632,7 @@ public class KeyValueClient extends BaseCacheableClient {
             RequestBody requestBody = RequestBody.create(json, MediaType.parse("application/json"));
             return http.extractConsulResponse(api.performTransaction(requestBody, query));
         } catch (JsonProcessingException e) {
-            throw new ConsulException(e);
+            throw new ConsulException("Error processing JSON", e);
         }
     }
 


### PR DESCRIPTION
* Deprecate constructor: ConsulException(int code, Response<?> response)
* Add new constructor to ConsulException with Call and Response arguments
* Provide additional context in ConsulException error messages
* Provide additional information in ConsulException messages when thrown from KeyValueClient and AgentClient
* Add method requestUrlOf in Http utility class and replace duplicated code in other Http methods and in ConsulException
* Add Javadocs to several existing constructors in ConsulException

Fixes #450
Fixes #451
Fixes #452