### PR TITLE
Fix flaky ServiceHealthCache race condition test

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/Awaiting.java
+++ b/src/itest/java/org/kiwiproject/consul/Awaiting.java
@@ -1,11 +1,14 @@
 package org.kiwiproject.consul;
 
 import static org.awaitility.Durations.FIVE_HUNDRED_MILLISECONDS;
+import static org.awaitility.Durations.FIVE_SECONDS;
 import static org.awaitility.Durations.ONE_HUNDRED_MILLISECONDS;
 import static org.awaitility.Durations.ONE_SECOND;
+import static org.awaitility.Durations.TWO_SECONDS;
 
 import org.awaitility.Awaitility;
 import org.awaitility.core.ConditionFactory;
+import org.testcontainers.shaded.org.bouncycastle.jcajce.provider.asymmetric.dsa.DSASigner.stdDSA;
 
 import java.time.Duration;
 
@@ -37,6 +40,13 @@ public class Awaiting {
      */
     public static ConditionFactory awaitAtMost1s() {
         return awaitWith25MsPoll().atMost(ONE_SECOND);
+    }
+
+    /**
+     * Awaits up to 2s with a 25ms poll interval.
+     */
+    public static ConditionFactory awaitAtMost2s() {
+        return awaitWith25MsPoll().atMost(TWO_SECONDS);
     }
 
     public static ConditionFactory awaitWith25MsPoll() {


### PR DESCRIPTION
Use a single-thread executor and CountDownLatch instead of spawning an uncoordinated thread to add a late listener. This removes timing issues and ensures deterministic notification of both listeners within a maxiumum time period.