### PR TITLE
Fix flaky EventClientITest#shouldListEventsByName

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/EventClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/EventClientITest.java
@@ -84,14 +84,16 @@ class EventClientITest extends BaseIntegrationTest {
         var event1 = events.get(index);
         var name = event1.getName();
 
-        // add another with the same name
-        var event2 = eventClient.fireEvent(name);
+        // fire several more events with the same name
+        eventClient.fireEvent(name);
+        eventClient.fireEvent(name);
+        eventClient.fireEvent(name);
 
         var eventResponse = eventClient.listEvents(name);
         assertThat(eventResponse.getEvents())
-                .describedAs("events should be in order of creation using the LTime (Lamport time)")
-                .extracting(Event::getId)
-                .containsExactly(event1.getId(), event2.getId());
+                .describedAs("events should have same name")
+                .extracting(Event::getName)
+                .containsOnly(name);
     }
 
     @Test


### PR DESCRIPTION
Consul does not guarantee any ordering of events, so I'm not sure why I made that assertion several years ago. Change the test to fire three additional events with the same name and then assert that the listEvents(String name) method returns only events with that name. Do NOT assert on the number of events as that cannot be guaranteed. The docs on the Consul Event state that "the gossip layer will make a best-effort to deliver the event, but there is no guaranteed delivery." In addition, the docs say regarding event data, "it is not persisted and does not have a total ordering," which means that "you cannot rely on the order of message delivery."

Even though there is no guaranteed delivery, in this test the chance of that is very small.

ref: https://developer.hashicorp.com/consul/commands/event