### PR TITLE
Populate lastCacheInfo with cache headers from ConsulResponse

### DIFF
--- a/src/itest/resources/logback-test.xml
+++ b/src/itest/resources/logback-test.xml
@@ -6,7 +6,7 @@
         </encoder>
     </appender>
 
-    <logger name="org.kiwiproject.consul" level="DEBUG"/>
+    <logger name="org.kiwiproject.consul" level="TRACE"/>
 
     <root level="WARN">
         <appender-ref ref="CONSOLE" />

--- a/src/test/java/org/kiwiproject/consul/cache/StubCallbackConsumer.java
+++ b/src/test/java/org/kiwiproject/consul/cache/StubCallbackConsumer.java
@@ -10,16 +10,24 @@ import java.util.List;
 public class StubCallbackConsumer implements ConsulCache.CallbackConsumer<Value> {
 
     private final List<Value> result;
+    private final String cacheHeader;
+    private final String ageHeader;
     private int callCount;
 
     public StubCallbackConsumer(List<Value> result) {
+        this(result, null, null);
+    }
+
+    public StubCallbackConsumer(List<Value> result, String cacheHeader, String ageHeader) {
         this.result = List.copyOf(result);
+        this.cacheHeader = cacheHeader;
+        this.ageHeader = ageHeader;
     }
 
     @Override
     public void consume(BigInteger index, ConsulResponseCallback<List<Value>> callback) {
         callCount++;
-        callback.onComplete(new ConsulResponse<>(result, 0, true, BigInteger.ZERO, null, null));
+        callback.onComplete(new ConsulResponse<>(result, 0, true, BigInteger.ZERO, cacheHeader, ageHeader));
     }
 
     public int getCallCount() {


### PR DESCRIPTION
- Set lastCacheInfo using cache headers in ConsulResponse.
- Add tests to verify cache header information populates correctly.
- Add constructor to StubCallbackConsumer that accepts cache hit/miss and age header values.
- Add TRACE-level logging in scheduleRunCallbackSafely to see information about the next schedule and delay, and also when we do not schedule because the cache isn't running.
- Increase the test log level to TRACE to see the new TRACE-level logging when scheduling the next callback.

Closes #470 