### PR TITLE
Switch integration tests to use ConsulContainer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,7 +205,7 @@
 
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>testcontainers</artifactId>
+            <artifactId>consul</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
* Change BaseIntegrationTest and AclClientITest to use ConsulContainer instead of GenericContainer. This eliminates some boilerplate code, and we only need to enable script checks in BaseIntegrationTest, not in AclClientITest.
* Fix several misspelled words in comments in BaseIntegrationTest
* Update the alias in the Awaitility statement in AclClientITest#ensureAclSubsystemIsReady so that the timeout matches (the alias says 5 seconds but it's really 20).

Closes #476