### PR TITLE
Upgrade OkHttp to version 5.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <!-- Versions for required dependencies -->
         <immutables.version>2.11.4</immutables.version>
         <kiwi-bom.version>2.1.1</kiwi-bom.version>
-        <okhttp.version>5.1.0</okhttp.version>
+        <okhttp.version>5.2.1</okhttp.version>
         <retrofit.version>3.0.0</retrofit.version>
 
         <!-- Versions for test dependencies -->
@@ -72,29 +72,13 @@
 
     <dependencyManagement>
         <dependencies>
-            <!-- Override the okhttp-bom version from kiwi-bom. Also need to set version for okhttp-jvm which is NOT in the BOM as of 5.1.0! -->
+            <!-- IMPORTANT: Override the okhttp-bom version from kiwi-bom. -->
             <dependency>
                 <groupId>com.squareup.okhttp3</groupId>
                 <artifactId>okhttp-bom</artifactId>
                 <version>${okhttp.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
-
-            <!--
-                As of 5.x, the okhttp JAR is empty and (in Maven) we need to use okhttp-jvm.
-
-                As mentioned above in the okhttp-bom import, unfortunately the OkHttp 5.1.0 BOM
-                does NOT include okhttp-jvm, so we need to make the version explicit here.
-
-                See:
-                * Issue "Empty okhttp jar for release 5.0.0 with Maven builds" at https://github.com/square/okhttp/issues/8913
-                * The "Maven and JVM Projects" section of the README at https://github.com/square/okhttp?tab=readme-ov-file#maven-and-jvm-projects
-            -->
-            <dependency>
-                <groupId>com.squareup.okhttp3</groupId>
-                <artifactId>okhttp-jvm</artifactId>
-                <version>${okhttp.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
- Bump okhttp from 5.1.0 to 5.2.1.
- Remove comments related to OkHttp 5.1.0 workarounds.
- Remove okhttp-jvm from dependency management; it's no longer required.

Closes #487