### PR TITLE
Add a constructor to ConsulResponse that takes a CacheResponseInfo

### DIFF
--- a/src/main/java/org/kiwiproject/consul/model/ConsulResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/ConsulResponse.java
@@ -5,6 +5,7 @@ import static java.util.Objects.nonNull;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Objects;
+import org.jspecify.annotations.Nullable;
 
 import java.math.BigInteger;
 import java.util.Optional;
@@ -56,22 +57,39 @@ public class ConsulResponse<T> {
     private final long lastContact;
     private final boolean knownLeader;
     private final BigInteger index;
-    private final Optional<CacheResponseInfo> cacheResponseInfo;
+    private final CacheResponseInfo cacheResponseInfo;
 
+    @Nullable
     @VisibleForTesting
     static CacheResponseInfo buildCacheResponseInfo(String headerHitMiss, String headerAge) throws NumberFormatException {
-        ConsulResponse.CacheResponseInfo cacheInfo = null;
         if (nonNull(headerHitMiss)) {
-            cacheInfo = new CacheResponseInfoImpl(headerHitMiss, headerAge);
+            return new CacheResponseInfoImpl(headerHitMiss, headerAge);
         }
-        return cacheInfo;
+        return null;
     }
 
-    public ConsulResponse(T response, long lastContact, boolean knownLeader, BigInteger index, String headerHitMiss, String headerAge) throws NumberFormatException {
-        this(response, lastContact, knownLeader, index, Optional.ofNullable(buildCacheResponseInfo(headerHitMiss, headerAge)));
+    public ConsulResponse(T response,
+                          long lastContact,
+                          boolean knownLeader,
+                          BigInteger index,
+                          String headerHitMiss,
+                          String headerAge) throws NumberFormatException {
+        this(response, lastContact, knownLeader, index, buildCacheResponseInfo(headerHitMiss, headerAge));
     }
 
-    public ConsulResponse(T response, long lastContact, boolean knownLeader, BigInteger index, Optional<CacheResponseInfo> cacheInfo) {
+    public ConsulResponse(T response,
+                          long lastContact,
+                          boolean knownLeader,
+                          BigInteger index,
+                          Optional<CacheResponseInfo> cacheInfo) {
+        this(response, lastContact, knownLeader, index, cacheInfo.orElse(null));
+    }
+
+    public ConsulResponse(T response,
+                          long lastContact,
+                          boolean knownLeader,
+                          BigInteger index,
+                          @Nullable CacheResponseInfo cacheInfo) {
         this.response = response;
         this.lastContact = lastContact;
         this.knownLeader = knownLeader;
@@ -111,7 +129,7 @@ public class ConsulResponse<T> {
      * @see <a href="https://developer.hashicorp.com/consul/api-docs/features/caching#background-refresh-caching">Background Refresh Caching</a>
      */
     public Optional<CacheResponseInfo> getCacheResponseInfo() {
-        return cacheResponseInfo;
+        return Optional.ofNullable(cacheResponseInfo);
     }
 
     @Override

--- a/src/test/java/org/kiwiproject/consul/model/ConsulResponseTest.java
+++ b/src/test/java/org/kiwiproject/consul/model/ConsulResponseTest.java
@@ -18,7 +18,7 @@ class ConsulResponseTest {
             var cacheMissResponse = new ConsulResponse<>(null, 0, false, null, "MISS", null);
             assertThat(cacheMissResponse.getCacheReponseInfo()).isPresent();
             assertThat(cacheMissResponse.getCacheResponseInfo()).isPresent();
-            assertThat(cacheMissResponse.getCacheReponseInfo()).isSameAs(cacheMissResponse.getCacheResponseInfo());
+            assertThat(cacheMissResponse.getCacheReponseInfo()).isEqualTo(cacheMissResponse.getCacheResponseInfo());
 
             var cacheResponseInfo = cacheMissResponse.getCacheResponseInfo().orElseThrow();
             assertThat(cacheResponseInfo.isCacheHit()).isFalse();
@@ -31,7 +31,7 @@ class ConsulResponseTest {
             var cacheHitResponse = new ConsulResponse<>(null, 0, false, null, "HIT", "42");
             assertThat(cacheHitResponse.getCacheReponseInfo()).isPresent();
             assertThat(cacheHitResponse.getCacheResponseInfo()).isPresent();
-            assertThat(cacheHitResponse.getCacheReponseInfo()).isSameAs(cacheHitResponse.getCacheResponseInfo());
+            assertThat(cacheHitResponse.getCacheReponseInfo()).isEqualTo(cacheHitResponse.getCacheResponseInfo());
 
             var cacheResponseInfo = cacheHitResponse.getCacheReponseInfo().orElseThrow();
             assertThat(cacheResponseInfo.isCacheHit()).isTrue();


### PR DESCRIPTION
- Add a new constructor that accepts a nullable CacheResponseInfo. The parameter is annotated with the JSpecify Nullable.
- Change the constructor that accepts Optional<CacheResponseInfo> to delegate to the new constructor.
- Reformat constructor argument lists to be on separate lines for readability.
- Change the cacheResponseInfo field to be a (nullable), which required changing getCacheResponseInfo() to wrap the field with an Optional. CacheResponseInfo instead of an Optional<CacheResponseInfo>.
- Refactor buildCacheResponseInfo so it doesn't use a temporary variable.
- Update tests so check for equality instead of the same object. They pass because the Optional wrapping the CacheResponseInfo is a different instance, but the wrapped value is the same object.

Closes #483