### PR TITLE
Deprecate ConsulResponse constructor with Optional parameter

### DIFF
--- a/src/main/java/org/kiwiproject/consul/model/ConsulResponse.java
+++ b/src/main/java/org/kiwiproject/consul/model/ConsulResponse.java
@@ -77,6 +77,11 @@ public class ConsulResponse<T> {
         this(response, lastContact, knownLeader, index, buildCacheResponseInfo(headerHitMiss, headerAge));
     }
 
+    /**
+     * @deprecated replaced by {@link #ConsulResponse(Object, long, boolean, BigInteger, CacheResponseInfo)}
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @Deprecated(since = "1.8.0", forRemoval = true)
     public ConsulResponse(T response,
                           long lastContact,
                           boolean knownLeader,


### PR DESCRIPTION
- Mark constructor using Optional as deprecated for removal since version 1.8.0.
- Add Deprecated annotation with the accompanying Javadoc reference to the replacement constructor.

Closes #482