### PR TITLE
Deprecate ConsistencyMode factory that accepts Optionals

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
@@ -483,8 +483,8 @@ class KeyValueClientITest extends BaseIntegrationTest {
                 .isFalse();
         assertThat(completed.getCount()).isOne();
 
-        var maxAgeInSeconds = Optional.of(60L);
-        var maxStaleInSeconds = Optional.of(180L);
+        var maxAgeInSeconds = 60L;
+        var maxStaleInSeconds = 180L;
         var consistencyMode = ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(maxAgeInSeconds, maxStaleInSeconds);
         var queryOptions = ImmutableQueryOptions.builder()
                 .consistencyMode(consistencyMode)

--- a/src/main/java/org/kiwiproject/consul/option/ConsistencyMode.java
+++ b/src/main/java/org/kiwiproject/consul/option/ConsistencyMode.java
@@ -69,7 +69,10 @@ public class ConsistencyMode {
      * @param maxStaleInSeconds Optional duration in seconds for which data can be stale if the server cannot be reached
      * @return a not null ConsistencyMode
      * @see <a href="https://developer.hashicorp.com/consul/api-docs/features/caching#simple-caching">Simple Caching</a>
+     * @deprecated replaced by {@link #createCachedConsistencyWithMaxAgeAndStale(Long, Long)}
      */
+    @SuppressWarnings({ "OptionalUsedAsFieldOrParameterType", "java:S1133", "DeprecatedIsStillUsed" })
+    @Deprecated(since = "1.8.0", forRemoval = true)
     public static ConsistencyMode createCachedConsistencyWithMaxAgeAndStale(Optional<Long> maxAgeInSeconds,
                                                                             Optional<Long> maxStaleInSeconds) {
         return createCachedConsistencyWithMaxAgeAndStale(

--- a/src/test/java/org/kiwiproject/consul/option/ConsistencyModeTest.java
+++ b/src/test/java/org/kiwiproject/consul/option/ConsistencyModeTest.java
@@ -23,6 +23,7 @@ class ConsistencyModeTest {
         assertThat(ConsistencyMode.values()[2].name()).isEqualTo("CONSISTENT");
     }
 
+    @SuppressWarnings("removal")
     @Test
     void checkHeadersForCached_WithOptionals() {
         var consistency = ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(Optional.of(30L), Optional.of(60L));
@@ -67,6 +68,7 @@ class ConsistencyModeTest {
         assertThat(consistency.getAdditionalHeaders()).isEmpty();
     }
 
+    @SuppressWarnings("removal")
     @Test
     void checkBadMaxAge_WithOptionals() {
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
@@ -79,6 +81,7 @@ class ConsistencyModeTest {
                 ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(-1L, null));
     }
 
+    @SuppressWarnings("removal")
     @Test
     void checkBadMaxStaleError_WithOptionals() {
         assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() ->
@@ -91,6 +94,7 @@ class ConsistencyModeTest {
                 ConsistencyMode.createCachedConsistencyWithMaxAgeAndStale(null, -2L));
     }
 
+    @SuppressWarnings("removal")
     @Test
     void shouldHaveToString_WithOptionals() {
         var maxAgeSeconds = Optional.of(30L);


### PR DESCRIPTION
* Deprecate the createCachedConsistencyWithMaxAgeAndStale method that accepts Optional arguments.
* Replace usages of the deprecated method in KeyValueClientITest.
* Suppress the various warnings about the deprecated method in ConsistencyMode and ConsistencyModeTest. Yeah, I know it's deprecated, thanks bro!

Closes #485