### PR TITLE
Rename FailoverTest to FailoverITest

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/failover/FailoverITest.java
+++ b/src/itest/java/org/kiwiproject/consul/failover/FailoverITest.java
@@ -13,7 +13,7 @@ import org.kiwiproject.consul.util.failover.MaxFailoverAttemptsExceededException
 import java.net.SocketTimeoutException;
 import java.util.List;
 
-class FailoverTest extends BaseIntegrationTest {
+class FailoverITest extends BaseIntegrationTest {
 
     /**
      * @implNote Without modifying the production code to allow inspection of interception results, there is no


### PR DESCRIPTION
This is to be consistent with all other integration tests, and also in case I try switching to use JUnit's new-ish suite features.