### PR TITLE
Remove Delombok action from CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,9 +52,6 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
 
-    - name: Delombok
-      uses: sleberknight/delombok-action@v0.8.0
-
     - name: Autobuild
       uses: github/codeql-action/autobuild@v4
 


### PR DESCRIPTION
This project does not use Lombok, so no reason to delombok anything!