### PR TITLE
Change the default value of "ping" to false in the Consul builder

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/ConsulITest.java
+++ b/src/itest/java/org/kiwiproject/consul/ConsulITest.java
@@ -12,4 +12,24 @@ class ConsulITest extends BaseIntegrationTest {
 
         assertThat(client.isDestroyed()).isTrue();
     }
+
+    @Test
+    void shouldBuildWithNoPing() {
+        var consul = Consul.builder()
+                .withHostAndPort(defaultClientHostAndPort)
+                .withPing(false)
+                .build();
+
+        assertThat(consul).isNotNull();
+    }
+
+    @Test
+    void shouldBuildWithPing() {
+        var consul = Consul.builder()
+                .withHostAndPort(defaultClientHostAndPort)
+                .withPing(true)
+                .build();
+
+        assertThat(consul).isNotNull();
+    }
 }

--- a/src/itest/java/org/kiwiproject/consul/failover/FailoverITest.java
+++ b/src/itest/java/org/kiwiproject/consul/failover/FailoverITest.java
@@ -69,6 +69,7 @@ class FailoverITest extends BaseIntegrationTest {
         // Create our consul instance
         var blacklistTimeInMillis = 200;
         var consulBuilder = Consul.builder()
+                .withPing(true)  // force it to fail (because the eager ping will fail)
                 .withMultipleHostAndPort(targets, blacklistTimeInMillis)
                 .withConnectTimeoutMillis(50)
                 .withMaxFailoverAttempts(2);  // this means we won't get to localhost!

--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -319,7 +319,7 @@ public class Consul {
         private X509TrustManager trustManager;
         private HostnameVerifier hostnameVerifier;
         private Proxy proxy;
-        private boolean ping = true;
+        private boolean ping;
         private Interceptor authInterceptor;
         private Interceptor aclTokenInterceptor;
         private Interceptor headerInterceptor;
@@ -374,11 +374,16 @@ public class Consul {
         }
 
         /**
-        * Instructs the builder that the AgentClient should attempt a ping before returning the Consul instance
-        *
-        * @param ping Whether the ping should be done or not
-        * @return The builder.
-        */
+         * Instructs the builder that the AgentClient should attempt a ping before returning the Consul instance.
+         * <p>
+         * The default value is {@code false} starting with version 1.9.0.
+         * <p>
+         * If you need immediate validation of Consul availability when the Consul instance is built,
+         * set this to {@code true}.
+         *
+         * @param ping Whether the ping should be done or not
+         * @return The builder.
+         */
         public Builder withPing(boolean ping) {
             this.ping = ping;
 


### PR DESCRIPTION
* Change ping default value to false in Consul.
* Update Javadoc on Consul.Builder#withPing with the new default value.
* Add tests to ConsulTest to verify behavior when no Consul agent is running.
* Add tests to ConsulITest to validate behavior when the Consul agent is running.
* Update test in FailoverITest that broke because it needed ping to be true to cause a failure.

Closes #509