### PR TITLE
Replace usage of deprecated URL constructors in Urls

### DIFF
--- a/src/main/java/org/kiwiproject/consul/util/UncheckedURISyntaxException.java
+++ b/src/main/java/org/kiwiproject/consul/util/UncheckedURISyntaxException.java
@@ -1,0 +1,27 @@
+package org.kiwiproject.consul.util;
+
+import static java.util.Objects.requireNonNull;
+
+import java.net.URISyntaxException;
+
+/**
+ * Wraps a {@link URISyntaxException} with an unchecked exception.
+ *
+ * @implNote This is copied from <a href="https://github.com/kiwiproject/kiwi">kiwi</a>.
+ * In the future, we may add kiwi as a dependency to this library, and then this can be replaced with the one in kiwi.
+ */
+public class UncheckedURISyntaxException extends RuntimeException {
+
+    public UncheckedURISyntaxException(String message, URISyntaxException cause) {
+        super(message, requireNonNull(cause));
+    }
+
+    public UncheckedURISyntaxException(URISyntaxException cause) {
+        super(requireNonNull(cause));
+    }
+
+    @Override
+    public synchronized URISyntaxException getCause() {
+        return (URISyntaxException) super.getCause();
+    }
+}

--- a/src/main/java/org/kiwiproject/consul/util/Urls.java
+++ b/src/main/java/org/kiwiproject/consul/util/Urls.java
@@ -1,6 +1,12 @@
 package org.kiwiproject.consul.util;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
+import org.jspecify.annotations.Nullable;
+
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 public class Urls {
@@ -11,21 +17,64 @@ public class Urls {
 
     public static URL newUrl(String urlString) {
         try {
-            return new URL(urlString);
+            return new URI(urlString).toURL();
+        } catch (URISyntaxException e) {
+            throw new UncheckedURISyntaxException(e);
         } catch (MalformedURLException e) {
             throw new UncheckedMalformedURLException(e);
         }
     }
 
     public static URL newUrl(String scheme, String host, int port) {
-        return newUrl(scheme, host, port, "");
+        return newUrl(scheme, host, port, null);
     }
 
-    public static URL newUrl(String scheme, String host, int port, String file) {
+    public static URL newUrl(String scheme, String host, int port, @Nullable String file) {
         try {
-            return new URL(scheme, host, port, file);
+            var urlFileComponents = parseAsUrlFile(file);
+            var uri = new URI(
+                    scheme,
+                    null,
+                    host,
+                    port,
+                    urlFileComponents.path(),
+                    urlFileComponents.query(),
+                    urlFileComponents.fragment()
+            );
+            return uri.toURL();
+        } catch (URISyntaxException e) {
+            throw new UncheckedURISyntaxException(e);
         } catch (MalformedURLException e) {
             throw new UncheckedMalformedURLException(e);
         }
+    }
+
+    private record UrlFileComponents(@Nullable String path, @Nullable String query, @Nullable String fragment) {
+    }
+
+    private static UrlFileComponents parseAsUrlFile(@Nullable String file) {
+        String path = file;
+        String query = null;
+        String fragment = null;
+
+        if (isBlank(file)) {
+            return new UrlFileComponents(null, null, null);
+        }
+
+        // Strip fragment
+        var fragmentIndex = path.indexOf('#');
+        if (fragmentIndex >= 0) {
+            fragment = path.substring(fragmentIndex + 1);
+            path = path.substring(0, fragmentIndex);
+        }
+
+        // Strip query
+        var queryIndex = path.indexOf('?');
+        if (queryIndex >= 0) {
+            query = path.substring(queryIndex + 1);
+            path = path.substring(0, queryIndex);
+        }
+
+        return new UrlFileComponents(path, query, fragment);
     }
 }

--- a/src/test/java/org/kiwiproject/consul/util/UncheckedURISyntaxExceptionTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/UncheckedURISyntaxExceptionTest.java
@@ -1,0 +1,38 @@
+package org.kiwiproject.consul.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.URISyntaxException;
+
+/**
+ * @implNote Copied from  <a href="https://github.com/kiwiproject/kiwi">kiwi</a>.
+ */
+@DisplayName("UncheckedURISyntaxException")
+class UncheckedURISyntaxExceptionTest {
+
+    @Test
+    void testConstructWithMessage() {
+        var cause = newURISyntaxException();
+        var exception = new UncheckedURISyntaxException("oops", cause);
+
+
+        assertThat(exception.getMessage()).isEqualTo("oops");
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    @Test
+    void testConstructWithoutMessage() {
+        var cause = newURISyntaxException();
+        var exception = new UncheckedURISyntaxException(cause);
+
+        assertThat(exception.getMessage()).contains(cause.getMessage());
+        assertThat(exception.getCause()).isSameAs(cause);
+    }
+
+    private static URISyntaxException newURISyntaxException() {
+        return new URISyntaxException("foo\\bar\\baz", "foo\\bar\\baz could not be parsed as a URI");
+    }
+}

--- a/src/test/java/org/kiwiproject/consul/util/UrlsTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/UrlsTest.java
@@ -1,9 +1,14 @@
 package org.kiwiproject.consul.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class UrlsTest {
 
@@ -16,8 +21,20 @@ class UrlsTest {
     }
 
     @Test
-    void shouldCreateNewUrl_FromString_AndThrow_WhenMalformed() {
-        assertThatExceptionOfType(UncheckedMalformedURLException.class).isThrownBy(() -> Urls.newUrl("oops"));
+    void createNewUrl_FromString_ShouldThrow_WhenNotAbsolute() {
+        assertThatIllegalArgumentException().isThrownBy(() -> Urls.newUrl("oops"));
+    }
+
+    @Test
+    void createNewUrl_FromString_ShouldThrow_WhenBadURISyntax() {
+        assertThatExceptionOfType(UncheckedURISyntaxException.class)
+                .isThrownBy(() -> Urls.newUrl("bad_protocol://acme.com:9876"));
+    }
+
+    @Test
+    void createNewUrl_FromString_ShouldThrow_WhenMalformed() {
+        assertThatExceptionOfType(UncheckedMalformedURLException.class)
+                .isThrownBy(() -> Urls.newUrl("nosuchscheme://example.com"));
     }
 
     @Test
@@ -28,7 +45,51 @@ class UrlsTest {
     }
 
     @Test
-    void shouldCreateNewUrl_FromComponents_AndThrow_WhenMalformed() {
-        assertThatExceptionOfType(UncheckedMalformedURLException.class).isThrownBy(() -> Urls.newUrl("bad_protocol", "github.com", 8080));
+    void createNewUrl_FromString_ShouldThrow_WhenPathNotAbsolute() {
+        assertThatExceptionOfType(UncheckedURISyntaxException.class)
+                .isThrownBy(() -> Urls.newUrl("https", "acme.com", 61000, "path"));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = { " ", "  " })
+    void shouldCreateNewUrl_FromComponents_AndNoFile(String file) {
+        var url = Urls.newUrl("https", "acme.com", 443, file);
+
+        assertThat(url).hasToString("https://acme.com:443");
+    }
+
+    @Test
+    void shouldCreateNewUrl_FromComponents_AndFile() {
+        var url = Urls.newUrl("https", "acme.com", 443, "/some-path");
+
+        assertThat(url).hasToString("https://acme.com:443/some-path");
+    }
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            /foo
+            /foo?bar=baz
+            /foo?bar=baz&a=b
+            /foo#a1
+            /foo#b1
+            /foo?bar=baz#a1
+            """)
+    void shouldCreateNewUrl_FromVariousFileArguments(String file) {
+        var url = Urls.newUrl("https", "acme.com", 8443, file);
+
+        assertThat(url).hasToString("https://acme.com:8443" + file);
+    }
+
+    @Test
+    void createNewUrl_FromComponents_ShouldThrow_WhenBadURISyntax() {
+        assertThatExceptionOfType(UncheckedURISyntaxException.class)
+                .isThrownBy(() -> Urls.newUrl("bad_protocol", "github.com", 8080));
+    }
+
+    @Test
+    void createNewUrl_FromComponents_ShouldThrow_WhenMalformed() {
+        assertThatExceptionOfType(UncheckedMalformedURLException.class)
+                .isThrownBy(() -> Urls.newUrl("nosuchscheme", "acme.com", 9876));
     }
 }


### PR DESCRIPTION
All URL constructors are deprecated. You are supposed to create a URI and then convert to URL using toURL(). This changes the Urls utility class to construct URIs and then convert using toURL(). We also have to handle additional exceptions that we didn't previously, mainly URISyntaxException thrown from URI constructors. We still need to handle MalformedURLException since toURL() throws it.

Additionally, we were using the URL constructor:

URL(String protocol, String host, int port, String file)

This takes a "file" which has a very specific meaning in the URL class. It includes the path, query, and fragment. There is no equivalent URI constructor. Instead, the comparable URI constructor accepts the path, query, and fragment as separate arguments.

To keep the functionality the same, we need to parse the "file" argument into separate path, query, and fragment values, and then pass those to the URI constructor. To handle URISyntaxException, the UncheckedURISyntaxException class from kiwi is copied here and thrown when there is a URI syntax error. It wraps the checked URISyntaxException.

Last, added Nullable annotation to the "file" argument in the newUrl method that has "file" as its last argument.