### PR TITLE
Simplify URI resolution of the path, query, and fragment in Urls

### DIFF
--- a/src/main/java/org/kiwiproject/consul/util/Urls.java
+++ b/src/main/java/org/kiwiproject/consul/util/Urls.java
@@ -31,50 +31,16 @@ public class Urls {
 
     public static URL newUrl(String scheme, String host, int port, @Nullable String file) {
         try {
-            var urlFileComponents = parseAsUrlFile(file);
-            var uri = new URI(
-                    scheme,
-                    null,
-                    host,
-                    port,
-                    urlFileComponents.path(),
-                    urlFileComponents.query(),
-                    urlFileComponents.fragment()
-            );
-            return uri.toURL();
+            var base = new URI(scheme, null, host, port, null, null, null);
+            if (isBlank(file)) {
+                return base.toURL();
+            }
+
+            return base.resolve(file).toURL();
         } catch (URISyntaxException e) {
             throw new UncheckedURISyntaxException(e);
         } catch (MalformedURLException e) {
             throw new UncheckedMalformedURLException(e);
         }
-    }
-
-    private record UrlFileComponents(@Nullable String path, @Nullable String query, @Nullable String fragment) {
-    }
-
-    private static UrlFileComponents parseAsUrlFile(@Nullable String file) {
-        String path = file;
-        String query = null;
-        String fragment = null;
-
-        if (isBlank(file)) {
-            return new UrlFileComponents(null, null, null);
-        }
-
-        // Strip fragment
-        var fragmentIndex = path.indexOf('#');
-        if (fragmentIndex >= 0) {
-            fragment = path.substring(fragmentIndex + 1);
-            path = path.substring(0, fragmentIndex);
-        }
-
-        // Strip query
-        var queryIndex = path.indexOf('?');
-        if (queryIndex >= 0) {
-            query = path.substring(queryIndex + 1);
-            path = path.substring(0, queryIndex);
-        }
-
-        return new UrlFileComponents(path, query, fragment);
     }
 }

--- a/src/test/java/org/kiwiproject/consul/util/UrlsTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/UrlsTest.java
@@ -45,9 +45,10 @@ class UrlsTest {
     }
 
     @Test
-    void createNewUrl_FromString_ShouldThrow_WhenPathNotAbsolute() {
-        assertThatExceptionOfType(UncheckedURISyntaxException.class)
-                .isThrownBy(() -> Urls.newUrl("https", "acme.com", 61000, "path"));
+    void shouldCreateNewUrl_FromComponents_ResolvingRelativePaths() {
+        var url = Urls.newUrl("https", "acme.com", 61000, "path");
+
+        assertThat(url).hasToString("https://acme.com:61000/path");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Refactor the complex parsing logic in Urls#newUrl to use URI#resolve. This has the nice benefit of handling relative paths, so resolving the (relative) path "orders" against https://store.acme.com:8443 results in the expected value of https://store.acme.com:8443/orders.