### PR TITLE
Suppress resource warnings in tests

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/cache/KVCacheITest.java
+++ b/src/itest/java/org/kiwiproject/consul/cache/KVCacheITest.java
@@ -306,6 +306,7 @@ class KVCacheITest extends BaseIntegrationTest {
 
     @ParameterizedTest(name = "queries of {0} seconds")
     @MethodSource("getBlockingQueriesDuration")
+    @SuppressWarnings("resource")
     void checkUpdateNotifications(int queryDurationSec) throws InterruptedException {
         var scheduledExecutor = Executors.newSingleThreadScheduledExecutor(
                 new ThreadFactoryBuilder().setDaemon(true).setNameFormat("kvcache-itest-%d").build()

--- a/src/itest/java/org/kiwiproject/consul/cache/ServiceHealthCacheITest.java
+++ b/src/itest/java/org/kiwiproject/consul/cache/ServiceHealthCacheITest.java
@@ -166,6 +166,7 @@ class ServiceHealthCacheITest extends BaseIntegrationTest {
     }
 
     @Test
+    @SuppressWarnings("resource")
     void shouldNotifyLateListenersRaceCondition() throws Exception {
         var serviceId = createAutoDeregisterServiceId();
         var serviceName = randomUUIDString();

--- a/src/test/java/org/kiwiproject/consul/cache/TimeoutInterceptorTest.java
+++ b/src/test/java/org/kiwiproject/consul/cache/TimeoutInterceptorTest.java
@@ -29,6 +29,7 @@ class TimeoutInterceptorTest {
 
     @ParameterizedTest(name = "expected timeout of {4} ms for url {0} with timeout of {1} ms and margin of {3} ms (enabled: {2})")
     @MethodSource("getInterceptParameters")
+    @SuppressWarnings("resource")
     void checkIntercept(String url, int defaultTimeout, boolean enabled, int margin, int expectedTimeoutMs)
             throws IOException {
 


### PR DESCRIPTION
Suppress IntelliJ \"resource used without try-with-resources\" warnings in three test methods:

- `KVCacheITest#checkUpdateNotifications`: `ScheduledExecutorService` is intentionally shut down via `shutdownNow()` in a `finally` block rather than try-with-resources, to force-stop rather than gracefully drain.
- `ServiceHealthCacheITest#shouldNotifyLateListenersRaceCondition`: same reason as above.
- `TimeoutInterceptorTest#checkIntercept`: `Response` is a Mockito mock and not a real resource requiring cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)