### PR TITLE
Add releaseLock overload that accepts a value

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
@@ -315,6 +315,34 @@ class KeyValueClientITest extends BaseIntegrationTest {
     }
 
     @Test
+    void acquireAndReleaseLockWithValue() {
+        var key = randomUUIDString();
+        var acquireValue = "acquired_by_" + randomUUIDString();
+        var releaseValue = "released_by_" + randomUUIDString();
+
+        SessionCreatedResponse response = sessionClient.createSession(ImmutableSession.builder().name(acquireValue).build());
+        String sessionId = response.getId();
+
+        try {
+            assertThat(keyValueClient.acquireLock(key, acquireValue, sessionId)).isTrue();
+
+            var valueAfterAcquireLock = keyValueClient.getValue(key).orElseThrow();
+            assertThat(valueAfterAcquireLock.getSession()).as("SessionId must be present.").isPresent();
+            assertThat(valueAfterAcquireLock.getValueAsString()).contains(acquireValue);
+
+            assertThat(keyValueClient.releaseLock(key, releaseValue, sessionId)).isTrue();
+
+            var valueAfterReleaseLock = keyValueClient.getValue(key).orElseThrow();
+            assertThat(valueAfterReleaseLock.getSession()).as("SessionId in the key value should be absent.").isEmpty();
+            assertThat(valueAfterReleaseLock.getValueAsString()).contains(releaseValue);
+
+            keyValueClient.deleteKey(key);
+        } finally {
+            sessionClient.destroySession(sessionId);
+        }
+    }
+
+    @Test
     void testGetSession() {
         var key = randomUUIDString();
         var value = randomUUIDString();

--- a/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/KeyValueClientITest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.consul;
 
 import static java.util.stream.Collectors.toUnmodifiableMap;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.assertj.core.api.Assertions.entry;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
 
@@ -327,14 +328,18 @@ class KeyValueClientITest extends BaseIntegrationTest {
             assertThat(keyValueClient.acquireLock(key, acquireValue, sessionId)).isTrue();
 
             var valueAfterAcquireLock = keyValueClient.getValue(key).orElseThrow();
-            assertThat(valueAfterAcquireLock.getSession()).as("SessionId must be present.").isPresent();
-            assertThat(valueAfterAcquireLock.getValueAsString()).contains(acquireValue);
+            assertAll(
+                () -> assertThat(valueAfterAcquireLock.getSession()).as("SessionId must be present.").isPresent(),
+                () -> assertThat(valueAfterAcquireLock.getValueAsString()).contains(acquireValue)
+            );
 
             assertThat(keyValueClient.releaseLock(key, releaseValue, sessionId)).isTrue();
 
             var valueAfterReleaseLock = keyValueClient.getValue(key).orElseThrow();
-            assertThat(valueAfterReleaseLock.getSession()).as("SessionId in the key value should be absent.").isEmpty();
-            assertThat(valueAfterReleaseLock.getValueAsString()).contains(releaseValue);
+            assertAll(
+                () -> assertThat(valueAfterReleaseLock.getSession()).as("SessionId in the key value should be absent.").isEmpty(),
+                () -> assertThat(valueAfterReleaseLock.getValueAsString()).contains(releaseValue)
+            );
 
             keyValueClient.deleteKey(key);
         } finally {

--- a/src/main/java/org/kiwiproject/consul/KeyValueClient.java
+++ b/src/main/java/org/kiwiproject/consul/KeyValueClient.java
@@ -16,7 +16,6 @@ import org.kiwiproject.consul.model.ConsulResponse;
 import org.kiwiproject.consul.model.kv.Operation;
 import org.kiwiproject.consul.model.kv.TxResponse;
 import org.kiwiproject.consul.model.kv.Value;
-import org.kiwiproject.consul.model.session.SessionInfo;
 import org.kiwiproject.consul.monitoring.ClientEventCallback;
 import org.kiwiproject.consul.option.ConsistencyMode;
 import org.kiwiproject.consul.option.DeleteOptions;

--- a/src/main/java/org/kiwiproject/consul/KeyValueClient.java
+++ b/src/main/java/org/kiwiproject/consul/KeyValueClient.java
@@ -606,16 +606,37 @@ public class KeyValueClient extends BaseCacheableClient {
     }
 
     /**
-     * Releases the lock for a given service and session.
+     * Releases the lock for a given key and session.
      * <p>
-     * GET /v1/kv/{key}?release={sessionId}
+     * PUT /v1/kv/{key}?release={sessionId}
+     * <p>
+     * The key value is set to an empty string. To preserve or update the value stored
+     * in the key when releasing the lock, use {@link #releaseLock(String, String, String)}.
      *
-     * @param key       identifying the service.
+     * @param key       the key identifying the lock
      * @param sessionId the session ID
-     * @return {@link SessionInfo}.
+     * @return true if the lock is released successfully, false otherwise
      */
     public boolean releaseLock(final String key, final String sessionId) {
-        return putValue(key, "", 0, ImmutablePutOptions.builder().release(sessionId).build());
+        return releaseLock(key, "", sessionId);
+    }
+
+    /**
+     * Releases the lock for a given key and session, storing a value in the key.
+     * <p>
+     * PUT /v1/kv/{key}?release={sessionId}
+     * <p>
+     * This overload mirrors {@link #acquireLock(String, String, String)}, allowing the
+     * caller to store application-specific data in the key (e.g., information about
+     * who released the lock) at the same time as releasing it.
+     *
+     * @param key       the key identifying the lock
+     * @param value     the value to store in the key (usually application-specific info)
+     * @param sessionId the session ID
+     * @return true if the lock is released successfully, false otherwise
+     */
+    public boolean releaseLock(final String key, final String value, final String sessionId) {
+        return putValue(key, value, 0, ImmutablePutOptions.builder().release(sessionId).build());
     }
 
     /**


### PR DESCRIPTION
Add releaseLock(key, value, sessionId) to mirror the existing acquireLock(key, value, session) overload. The new overload allows callers to store application-specific data in the key at the same time as releasing the lock (e.g. information about who released it).

The existing releaseLock(key, sessionId) now delegates to the new overload with an empty string value, preserving backward compatibility.