### PR TITLE
Add AuthTokenProvider for dynamic token refresh in Consul.Builder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <retrofit.version>3.0.0</retrofit.version>
 
         <!-- Versions for test dependencies -->
-        <mockwebserver3.version>5.3.2</mockwebserver3.version>
+        <!-- nothing to see here yet...move along...move along... -->
 
         <!-- Versions for plugins -->
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
@@ -198,7 +198,6 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>mockwebserver3-junit5</artifactId>
-            <version>${mockwebserver3.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <retrofit.version>3.0.0</retrofit.version>
 
         <!-- Versions for test dependencies -->
-        <!-- nothing to see here yet...move along...move along... -->
+        <mockwebserver3.version>5.3.2</mockwebserver3.version>
 
         <!-- Versions for plugins -->
         <build-helper-maven-plugin.version>3.6.1</build-helper-maven-plugin.version>
@@ -192,6 +192,13 @@
             <groupId>com.squareup.retrofit2</groupId>
             <artifactId>retrofit-mock</artifactId>
             <version>${retrofit.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver3-junit5</artifactId>
+            <version>${mockwebserver3.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/org/kiwiproject/consul/AuthTokenProvider.java
+++ b/src/main/java/org/kiwiproject/consul/AuthTokenProvider.java
@@ -19,7 +19,7 @@ public interface AuthTokenProvider {
      * Returns the current ACL token to use for the next request.
      * <p>
      * Implementations must not return null. Returning null will cause a
-     * {@link NullPointerException} to be thrown when the request is processed.
+     * {@link NullPointerException} to be thrown directly when the request is processed.
      *
      * @return the token string, never null
      */

--- a/src/main/java/org/kiwiproject/consul/AuthTokenProvider.java
+++ b/src/main/java/org/kiwiproject/consul/AuthTokenProvider.java
@@ -17,8 +17,11 @@ public interface AuthTokenProvider {
 
     /**
      * Returns the current ACL token to use for the next request.
+     * <p>
+     * Implementations must not return null. Returning null will cause a
+     * {@link NullPointerException} to be thrown when the request is processed.
      *
-     * @return the token string
+     * @return the token string, never null
      */
     String getToken();
 }

--- a/src/main/java/org/kiwiproject/consul/AuthTokenProvider.java
+++ b/src/main/java/org/kiwiproject/consul/AuthTokenProvider.java
@@ -1,0 +1,24 @@
+package org.kiwiproject.consul;
+
+/**
+ * Provides an ACL token for authenticating requests to Consul.
+ * <p>
+ * Implementations are called on every request, allowing tokens to be
+ * refreshed dynamically without rebuilding the {@link Consul} client.
+ * This is useful when tokens expire and must be reloaded periodically.
+ * <p>
+ * For static tokens, use {@link Consul.Builder#withTokenAuth(String)},
+ * which is implemented in terms of this interface.
+ *
+ * @see Consul.Builder#withTokenAuth(AuthTokenProvider)
+ */
+@FunctionalInterface
+public interface AuthTokenProvider {
+
+    /**
+     * Returns the current ACL token to use for the next request.
+     *
+     * @return the token string
+     */
+    String getToken();
+}

--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -415,17 +415,37 @@ public class Consul {
         }
 
         /**
-         * Sets the token used for authentication
+         * Sets the token used for authentication.
+         * <p>
+         * The token is captured at build time and sent as the X-Consul-Token header
+         * on every request. For tokens that may expire and need to be refreshed
+         * dynamically, use {@link #withTokenAuth(AuthTokenProvider)} instead.
          *
          * @param token the token
          * @return The builder.
          */
         public Builder withTokenAuth(String token) {
+            return withTokenAuth(() -> token);
+        }
+
+        /**
+         * Sets a dynamic token provider used for authentication.
+         * <p>
+         * The provider is called on every request, allowing the token to be
+         * refreshed without rebuilding the {@link Consul} client. This is useful
+         * when tokens expire and must be reloaded periodically.
+         * <p>
+         * For static tokens, use {@link #withTokenAuth(String)}.
+         *
+         * @param tokenProvider the provider that supplies the current token
+         * @return The builder.
+         */
+        public Builder withTokenAuth(AuthTokenProvider tokenProvider) {
             authInterceptor = chain -> {
                 Request original = chain.request();
 
                 Request.Builder requestBuilder = original.newBuilder()
-                        .header("X-Consul-Token", token)
+                        .header("X-Consul-Token", tokenProvider.getToken())
                         .method(original.method(), original.body());
 
                 Request request = requestBuilder.build();

--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -437,8 +437,10 @@ public class Consul {
          * <p>
          * For static tokens, use {@link #withTokenAuth(String)}.
          *
-         * @param tokenProvider the provider that supplies the current token
+         * @param tokenProvider the provider that supplies the current token; must not be null,
+         *                      and {@link AuthTokenProvider#getToken()} must not return null
          * @return The builder.
+         * @throws IllegalArgumentException if tokenProvider is null
          */
         public Builder withTokenAuth(AuthTokenProvider tokenProvider) {
             checkArgument(nonNull(tokenProvider), "tokenProvider must not be null");

--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -441,6 +441,7 @@ public class Consul {
          * @return The builder.
          */
         public Builder withTokenAuth(AuthTokenProvider tokenProvider) {
+            checkArgument(nonNull(tokenProvider), "tokenProvider must not be null");
             authInterceptor = chain -> {
                 Request original = chain.request();
 

--- a/src/test/java/org/kiwiproject/consul/ConsulTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulTest.java
@@ -316,6 +316,19 @@ class ConsulTest {
                     .isThrownBy(() -> Consul.builder().withTokenAuth((AuthTokenProvider) null))
                     .withMessage("tokenProvider must not be null");
         }
+
+        @Test
+        void shouldThrowNullPointerException_WhenTokenProviderReturnsNull() {
+            server.enqueue(new MockResponse.Builder().code(200).body(LEADER_RESPONSE_BODY).build());
+
+            var consul = Consul.builder()
+                    .withUrl(server.url("/").toString())
+                    .withTokenAuth(() -> null)
+                    .build();
+
+            assertThatExceptionOfType(NullPointerException.class)
+                    .isThrownBy(() -> consul.statusClient().getLeader());
+        }
     }
 
     @Nested

--- a/src/test/java/org/kiwiproject/consul/ConsulTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulTest.java
@@ -10,6 +10,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.google.common.net.HostAndPort;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import mockwebserver3.junit5.StartStop;
 import okhttp3.OkHttpClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,6 +37,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 @DisplayName("Consul")
@@ -243,6 +247,67 @@ class ConsulTest {
         public X509Certificate[] getAcceptedIssuers() {
             // Return an empty array of certificate authorities
             return new X509Certificate[0];
+        }
+    }
+
+    @Nested
+    class WithTokenAuth {
+
+        private static final String LEADER_RESPONSE_BODY = "\"127.0.0.1:8300\"";
+
+        @StartStop
+        public final MockWebServer server = new MockWebServer();
+
+        @Test
+        void shouldSendStaticTokenAsHeader() throws Exception {
+            server.enqueue(new MockResponse.Builder().code(200).body(LEADER_RESPONSE_BODY).build());
+
+            var consul = Consul.builder()
+                    .withUrl(server.url("/").toString())
+                    .withTokenAuth("static-token")
+                    .build();
+
+            consul.statusClient().getLeader();
+
+            var recordedRequest = server.takeRequest();
+            assertThat(recordedRequest.getHeaders().get("X-Consul-Token")).isEqualTo("static-token");
+        }
+
+        @Test
+        void shouldSendTokenFromProviderAsHeader() throws Exception {
+            server.enqueue(new MockResponse.Builder().code(200).body(LEADER_RESPONSE_BODY).build());
+
+            var consul = Consul.builder()
+                    .withUrl(server.url("/").toString())
+                    .withTokenAuth(() -> "provider-token")
+                    .build();
+
+            consul.statusClient().getLeader();
+
+            var recordedRequest = server.takeRequest();
+            assertThat(recordedRequest.getHeaders().get("X-Consul-Token")).isEqualTo("provider-token");
+        }
+
+        @Test
+        void shouldUseCurrentTokenOnEachRequest() {
+            server.enqueue(new MockResponse.Builder().code(200).body(LEADER_RESPONSE_BODY).build());
+            server.enqueue(new MockResponse.Builder().code(200).body(LEADER_RESPONSE_BODY).build());
+
+            var tokens = new String[]{"token-v1", "token-v2"};
+            var callCount = new AtomicInteger();
+
+            var consul = Consul.builder()
+                    .withUrl(server.url("/").toString())
+                    .withTokenAuth(() -> tokens[callCount.getAndIncrement()])
+                    .build();
+
+            consul.statusClient().getLeader();
+            consul.statusClient().getLeader();
+
+            assertAll(
+                () -> assertThat(server.takeRequest().getHeaders().get("X-Consul-Token")).isEqualTo("token-v1"),
+                () -> assertThat(server.takeRequest().getHeaders().get("X-Consul-Token")).isEqualTo("token-v2")
+            );
         }
     }
 

--- a/src/test/java/org/kiwiproject/consul/ConsulTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulTest.java
@@ -3,6 +3,7 @@ package org.kiwiproject.consul;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.kiwiproject.consul.TestUtils.findFirstOpenPortFromOrThrow;
@@ -326,7 +327,7 @@ class ConsulTest {
                     .withTokenAuth(() -> null)
                     .build();
 
-            assertThatExceptionOfType(NullPointerException.class)
+            assertThatNullPointerException()
                     .isThrownBy(() -> consul.statusClient().getLeader());
         }
     }

--- a/src/test/java/org/kiwiproject/consul/ConsulTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulTest.java
@@ -309,6 +309,13 @@ class ConsulTest {
                 () -> assertThat(server.takeRequest().getHeaders().get("X-Consul-Token")).isEqualTo("token-v2")
             );
         }
+
+        @Test
+        void shouldRejectNullTokenProvider() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> Consul.builder().withTokenAuth((AuthTokenProvider) null))
+                    .withMessage("tokenProvider must not be null");
+        }
     }
 
     @Nested


### PR DESCRIPTION
Add AuthTokenProvider, a functional interface whose getToken() method is called on every request, allowing tokens to be refreshed dynamically without rebuilding the Consul client. This is useful when tokens expire and must be reloaded periodically.

Add withTokenAuth(AuthTokenProvider) to Consul.Builder. The existing withTokenAuth(String) now delegates to the new overload via a lambda, preserving full backward compatibility.

Add mockwebserver3-junit5 as a test dependency to enable proper HTTP-level verification of interceptor behavior. Add three tests covering static token, provider-based token, and per-request token refresh.