### PR TITLE
Add Unix domain socket support for local Consul agent communication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
 
     <artifactId>consul-client</artifactId>
-    <version>1.11.1-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -54,7 +54,7 @@
     <properties>
         <!-- Versions for required dependencies -->
         <immutables.version>2.12.1</immutables.version>
-        <kiwi-bom.version>3.0.4</kiwi-bom.version>
+        <kiwi-bom.version>3.1.0</kiwi-bom.version>
         <retrofit.version>3.0.0</retrofit.version>
 
         <!-- Versions for test dependencies -->
@@ -160,6 +160,13 @@
         <dependency>
             <groupId>jakarta.annotation</groupId>
             <artifactId>jakarta.annotation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.kohlschutter.junixsocket</groupId>
+            <artifactId>junixsocket-core</artifactId>
+            <type>pom</type>
+            <optional>true</optional>
         </dependency>
 
         <!-- Test dependencies -->

--- a/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
+++ b/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
@@ -51,10 +51,17 @@ class UnixDomainSocketITest {
         var socketAddress = CONTAINER_SOCKET_DIR + "/" + SOCKET_FILE_NAME;
 
         consulContainer = new GenericContainer<>(CONSUL_DOCKER_IMAGE_NAME)
-                .withCommand(
-                        "agent", "-dev",
-                        "-hcl", "addresses { http = \"unix://" + socketAddress + "\" }",
-                        "-hcl", "ports { http = -1 }")
+                .withCommand("agent", "-dev")
+                .withEnv("CONSUL_LOCAL_CONFIG", """
+                        {
+                            "addresses": {
+                                "http": "unix://%s"
+                            },
+                            "ports": {
+                                "http": -1
+                            }
+                        }
+                        """.formatted(socketAddress))
                 .withFileSystemBind(socketDir.toAbsolutePath().toString(),
                         CONTAINER_SOCKET_DIR, BindMode.READ_WRITE)
                 .waitingFor(Wait.forLogMessage(".*agent: Synced node info.*", 1));

--- a/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
+++ b/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
@@ -6,13 +6,17 @@ import static org.awaitility.Awaitility.await;
 import static org.kiwiproject.consul.ConsulTestcontainers.CONSUL_DOCKER_IMAGE_NAME;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
 
+import org.awaitility.core.ConditionTimeoutException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.io.IOException;
@@ -20,6 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
+import java.util.stream.Collectors;
 
 /**
  * Integration test for Unix domain socket support.
@@ -31,6 +36,8 @@ import java.time.Duration;
  */
 @EnabledOnOs(OS.LINUX)
 class UnixDomainSocketITest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UnixDomainSocketITest.class);
 
     private static final String SOCKET_FILE_NAME = "consul.sock";
     private static final String CONTAINER_SOCKET_DIR = "/consul-socket";
@@ -48,6 +55,10 @@ class UnixDomainSocketITest {
                 PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx")));
         socketPath = socketDir.resolve(SOCKET_FILE_NAME);
 
+        LOG.info("Socket dir: {} (permissions: {})",
+                socketDir,
+                Files.getPosixFilePermissions(socketDir));
+
         var socketAddress = CONTAINER_SOCKET_DIR + "/" + SOCKET_FILE_NAME;
 
         consulContainer = new GenericContainer<>(CONSUL_DOCKER_IMAGE_NAME)
@@ -64,13 +75,24 @@ class UnixDomainSocketITest {
                         """.formatted(socketAddress))
                 .withFileSystemBind(socketDir.toAbsolutePath().toString(),
                         CONTAINER_SOCKET_DIR, BindMode.READ_WRITE)
+                .withLogConsumer(new Slf4jLogConsumer(LOG).withPrefix("consul"))
                 .waitingFor(Wait.forLogMessage(".*agent: Synced node info.*", 1));
 
         consulContainer.start();
 
-        await().atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofMillis(500))
-                .until(() -> Files.exists(socketPath));
+        try {
+            await().atMost(Duration.ofSeconds(30))
+                    .pollInterval(Duration.ofMillis(500))
+                    .until(() -> Files.exists(socketPath));
+        } catch (ConditionTimeoutException e) {
+            try (var entries = Files.list(socketDir)) {
+                var contents = entries.map(Path::toString).collect(Collectors.joining(", "));
+                LOG.error("Socket file not found at {} after 30s. Directory contents: [{}]",
+                        socketPath, contents.isEmpty() ? "<empty>" : contents);
+            }
+            LOG.error("Container logs:\n{}", consulContainer.getLogs());
+            throw e;
+        }
 
         client = Consul.builder()
                 .withUnixDomainSocket(socketPath)

--- a/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
+++ b/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
@@ -2,6 +2,7 @@ package org.kiwiproject.consul;
 
 import static java.util.Objects.nonNull;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 import static org.kiwiproject.consul.ConsulTestcontainers.CONSUL_DOCKER_IMAGE_NAME;
 import static org.kiwiproject.consul.TestUtils.randomUUIDString;
 
@@ -17,6 +18,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 
 /**
  * Integration test for Unix domain socket support.
@@ -55,6 +57,10 @@ class UnixDomainSocketITest {
                 .waitingFor(Wait.forLogMessage(".*agent: Synced node info.*", 1));
 
         consulContainer.start();
+
+        await().atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(500))
+                .until(() -> Files.exists(socketPath));
 
         client = Consul.builder()
                 .withUnixDomainSocket(socketPath)

--- a/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
+++ b/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
@@ -66,6 +66,9 @@ class UnixDomainSocketITest {
                         {
                             "addresses": {
                                 "http": "unix://%s"
+                            },
+                            "unix_sockets": {
+                                "mode": "0777"
                             }
                         }
                         """.formatted(socketAddress))

--- a/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
+++ b/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
@@ -92,6 +92,10 @@ class UnixDomainSocketITest {
             throw e;
         }
 
+        LOG.info("Socket file: {} (permissions: {})",
+                socketPath,
+                Files.getPosixFilePermissions(socketPath));
+
         client = Consul.builder()
                 .withUnixDomainSocket(socketPath)
                 .build();

--- a/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
+++ b/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
@@ -50,9 +50,8 @@ class UnixDomainSocketITest {
     @BeforeAll
     @SuppressWarnings("resource")
     static void beforeAll() throws IOException {
-        socketDir = Files.createTempDirectory(
-                null,
-                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx")));
+        socketDir = Files.createTempDirectory("consul-uds-itest-");
+        Files.setPosixFilePermissions(socketDir, PosixFilePermissions.fromString("rwxrwxrwx"));
         socketPath = socketDir.resolve(SOCKET_FILE_NAME);
 
         LOG.info("Socket dir: {} (permissions: {})",
@@ -67,9 +66,6 @@ class UnixDomainSocketITest {
                         {
                             "addresses": {
                                 "http": "unix://%s"
-                            },
-                            "ports": {
-                                "http": -1
                             }
                         }
                         """.formatted(socketAddress))

--- a/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
+++ b/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
@@ -1,0 +1,95 @@
+package org.kiwiproject.consul;
+
+import static java.util.Objects.nonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.kiwiproject.consul.ConsulTestcontainers.CONSUL_DOCKER_IMAGE_NAME;
+import static org.kiwiproject.consul.TestUtils.randomUUIDString;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Integration test for Unix domain socket support.
+ *
+ * @implNote This test is Linux-only. Docker Desktop on macOS runs containers
+ * inside a Linux VM; bind-mounted directories sync regular files but Unix domain
+ * socket endpoints only exist in the VM's kernel, so a macOS host process cannot
+ * connect() to them. Run this on Linux or in CI.
+ */
+@EnabledOnOs(OS.LINUX)
+class UnixDomainSocketITest {
+
+    private static final String SOCKET_FILE_NAME = "consul.sock";
+    private static final String CONTAINER_SOCKET_DIR = "/consul-socket";
+
+    private static GenericContainer<?> consulContainer;
+    private static Path socketDir;
+    private static Path socketPath;
+    private static Consul client;
+
+    @BeforeAll
+    @SuppressWarnings("resource")
+    static void beforeAll() throws IOException {
+        socketDir = Files.createTempDirectory("consul-uds-itest-");
+        socketPath = socketDir.resolve(SOCKET_FILE_NAME);
+
+        var socketAddress = CONTAINER_SOCKET_DIR + "/" + SOCKET_FILE_NAME;
+
+        consulContainer = new GenericContainer<>(CONSUL_DOCKER_IMAGE_NAME)
+                .withCommand(
+                        "agent", "-dev",
+                        "-hcl", "addresses { http = \"unix://" + socketAddress + "\" }",
+                        "-hcl", "ports { http = -1 }")
+                .withFileSystemBind(socketDir.toAbsolutePath().toString(),
+                        CONTAINER_SOCKET_DIR, BindMode.READ_WRITE)
+                .waitingFor(Wait.forLogMessage(".*agent: Synced node info.*", 1));
+
+        consulContainer.start();
+
+        client = Consul.builder()
+                .withUnixDomainSocket(socketPath)
+                .build();
+    }
+
+    @AfterAll
+    static void afterAll() throws IOException {
+        if (nonNull(client)) {
+            client.destroy();
+        }
+        if (nonNull(consulContainer)) {
+            consulContainer.stop();
+        }
+        Files.deleteIfExists(socketPath);
+        Files.deleteIfExists(socketDir);
+    }
+
+    @Test
+    void shouldReturnLeader() {
+        var leader = client.statusClient().getLeader();
+        assertThat(leader).isNotBlank();
+    }
+
+    @Test
+    void shouldRoundTripKeyValue() {
+        var key = "uds-test/" + randomUUIDString();
+        var value = "hello-from-uds";
+
+        var kvClient = client.keyValueClient();
+        kvClient.putValue(key, value);
+
+        var retrieved = kvClient.getValueAsString(key);
+        assertThat(retrieved).isPresent().hasValue(value);
+
+        kvClient.deleteKey(key);
+    }
+}

--- a/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
+++ b/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
@@ -61,7 +61,6 @@ class UnixDomainSocketITest {
         var socketAddress = CONTAINER_SOCKET_DIR + "/" + SOCKET_FILE_NAME;
 
         consulContainer = new GenericContainer<>(CONSUL_DOCKER_IMAGE_NAME)
-                .withCommand("agent", "-dev")
                 .withEnv("CONSUL_LOCAL_CONFIG", """
                         {
                             "addresses": {

--- a/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
+++ b/src/itest/java/org/kiwiproject/consul/UnixDomainSocketITest.java
@@ -18,6 +18,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Duration;
 
 /**
@@ -42,7 +43,9 @@ class UnixDomainSocketITest {
     @BeforeAll
     @SuppressWarnings("resource")
     static void beforeAll() throws IOException {
-        socketDir = Files.createTempDirectory("consul-uds-itest-");
+        socketDir = Files.createTempDirectory(
+                null,
+                PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxrwxrwx")));
         socketPath = socketDir.resolve(SOCKET_FILE_NAME);
 
         var socketAddress = CONTAINER_SOCKET_DIR + "/" + SOCKET_FILE_NAME;

--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -36,6 +36,7 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.X509TrustManager;
 import java.net.Proxy;
 import java.net.URL;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Base64;
 import java.util.Collection;
@@ -319,6 +320,7 @@ public class Consul {
         private X509TrustManager trustManager;
         private HostnameVerifier hostnameVerifier;
         private Proxy proxy;
+        private Path unixSocketPath;
         private boolean ping;
         private Interceptor authInterceptor;
         private Interceptor aclTokenInterceptor;
@@ -745,6 +747,40 @@ public class Consul {
         }
 
         /**
+         * Connects to the local Consul agent via a Unix domain socket at the given path.
+         * <p>
+         * Requires the {@code junixsocket-core} dependency on the classpath.
+         * <p>
+         * Cannot be combined with an SSL context; {@link #build()} throws
+         * {@link IllegalStateException} if both are configured.
+         *
+         * @param socketPath path to the Unix domain socket file
+         * @return The builder.
+         */
+        public Builder withUnixDomainSocket(Path socketPath) {
+            this.unixSocketPath = socketPath;
+            return this;
+        }
+
+        /**
+         * Connects to the local Consul agent via a Unix domain socket at the given path.
+         * <p>
+         * Requires the {@code junixsocket-core} dependency on the classpath.
+         * <p>
+         * Cannot be combined with an SSL context; {@link #build()} throws
+         * {@link IllegalStateException} if both are configured.
+         *
+         * @param socketPath path to the Unix domain socket file; must not be null or blank
+         * @return The builder.
+         * @throws IllegalArgumentException if socketPath is null or blank
+         */
+        public Builder withUnixDomainSocket(String socketPath) {
+            checkArgument(nonNull(socketPath) && !socketPath.isBlank(),
+                    "socketPath must not be null or blank");
+            return withUnixDomainSocket(Path.of(socketPath));
+        }
+
+        /**
         * Connect timeout for OkHttpClient
         * @param timeoutMillis timeout values in milliseconds
         * @return The builder
@@ -864,6 +900,12 @@ public class Consul {
                 connectionPool = new ConnectionPool();
             }
 
+            if (nonNull(unixSocketPath) && nonNull(sslContext)) {
+                throw new IllegalStateException(
+                        "Cannot use a Unix domain socket with SSL/TLS; " +
+                                "configure withUnixDomainSocket or an SSL context, not both");
+            }
+
             ClientConfig config = nonNull(clientConfig) ? clientConfig : new ClientConfig();
 
             var okHttpClient = createOkHttpClient(
@@ -968,6 +1010,8 @@ public class Consul {
                 builder.proxy(proxy);
             }
 
+            addUnixDomainSocketFactory(unixSocketPath, builder);
+
             var networkTimeoutConfig = networkTimeoutConfigBuilder.build();
             addTimeouts(builder, networkTimeoutConfig);
 
@@ -1011,6 +1055,16 @@ public class Consul {
             } else {
                 builder.sslSocketFactory(socketFactory, TrustManagerUtils.getDefaultTrustManager());
             }
+        }
+
+        @VisibleForTesting
+        static void addUnixDomainSocketFactory(@Nullable Path unixSocketPath,
+                                               OkHttpClient.Builder builder) {
+            if (isNull(unixSocketPath)) {
+                return;
+            }
+            builder.socketFactory(new UnixDomainSocketFactory(unixSocketPath));
+            builder.proxy(Proxy.NO_PROXY);
         }
 
         private static void addTimeouts(OkHttpClient.Builder builder,

--- a/src/main/java/org/kiwiproject/consul/Consul.java
+++ b/src/main/java/org/kiwiproject/consul/Consul.java
@@ -754,10 +754,12 @@ public class Consul {
          * Cannot be combined with an SSL context; {@link #build()} throws
          * {@link IllegalStateException} if both are configured.
          *
-         * @param socketPath path to the Unix domain socket file
+         * @param socketPath path to the Unix domain socket file; must not be null
          * @return The builder.
+         * @throws IllegalArgumentException if socketPath is null
          */
         public Builder withUnixDomainSocket(Path socketPath) {
+            checkArgument(nonNull(socketPath), "socketPath must not be null");
             this.unixSocketPath = socketPath;
             return this;
         }

--- a/src/main/java/org/kiwiproject/consul/UnixDomainSocketFactory.java
+++ b/src/main/java/org/kiwiproject/consul/UnixDomainSocketFactory.java
@@ -1,0 +1,147 @@
+package org.kiwiproject.consul;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
+
+import javax.net.SocketFactory;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.nio.file.Path;
+
+/**
+ * A {@link SocketFactory} that creates connections to a local Consul agent
+ * via a Unix domain socket instead of TCP.
+ * <p>
+ * All {@code createSocket} overloads ignore the host and port arguments and
+ * connect to the configured socket path.
+ * <p>
+ * The no-arg {@link #createSocket()} returns an unconnected socket wrapper
+ * whose {@code connect()} method redirects to the Unix socket path. This is
+ * required because OkHttp calls the no-arg {@code createSocket()} and then
+ * calls {@code connect(InetSocketAddress)} separately; returning an
+ * already-connected {@code AFUNIXSocket} there would cause junixsocket to
+ * attempt (and fail) to map the TCP address via {@code AFSocketAddress.mapOrFail}.
+ * <p>
+ * The overloads that accept a host/port return an already-connected socket
+ * directly, since callers of those variants do not make a separate
+ * {@code connect()} call.
+ * <p>
+ * Requires the {@code junixsocket-core} dependency on the classpath.
+ *
+ * @see Consul.Builder#withUnixDomainSocket(Path)
+ * @see Consul.Builder#withUnixDomainSocket(String)
+ */
+public class UnixDomainSocketFactory extends SocketFactory {
+
+    private final Path socketPath;
+
+    /**
+     * Creates a new factory that connects to the given Unix domain socket path.
+     *
+     * @param socketPath path to the Unix domain socket file
+     */
+    public UnixDomainSocketFactory(Path socketPath) {
+        this.socketPath = socketPath;
+    }
+
+    /**
+     * Returns a socket wrapper backed by an unconnected {@link AFUNIXSocket}.
+     * The wrapper's {@code connect()} methods ignore the supplied address and
+     * always connect to {@link #socketPath}, so that OkHttp's standard
+     * {@code createSocket()} + {@code connect(InetSocketAddress)} flow works
+     * correctly with Unix domain sockets.
+     */
+    @Override
+    public Socket createSocket() throws IOException {
+        var unixSocket = newAFUNIXSocket();
+        var unixAddress = AFUNIXSocketAddress.of(socketPath);
+        return new Socket() {
+            @Override
+            public void connect(SocketAddress endpoint) throws IOException {
+                unixSocket.connect(unixAddress);
+            }
+
+            @Override
+            public void connect(SocketAddress endpoint, int timeout) throws IOException {
+                unixSocket.connect(unixAddress, timeout);
+            }
+
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return unixSocket.getInputStream();
+            }
+
+            @Override
+            public OutputStream getOutputStream() throws IOException {
+                return unixSocket.getOutputStream();
+            }
+
+            @Override
+            public boolean isConnected() {
+                return unixSocket.isConnected();
+            }
+
+            @Override
+            public boolean isClosed() {
+                return unixSocket.isClosed();
+            }
+
+            @Override
+            public boolean isInputShutdown() {
+                return unixSocket.isInputShutdown();
+            }
+
+            @Override
+            public boolean isOutputShutdown() {
+                return unixSocket.isOutputShutdown();
+            }
+
+            @Override
+            public synchronized void close() throws IOException {
+                unixSocket.close();
+            }
+        };
+    }
+
+    /**
+     * Creates a new, unconnected {@link AFUNIXSocket}.
+     */
+    @VisibleForTesting
+    protected AFUNIXSocket newAFUNIXSocket() throws IOException {
+        return AFUNIXSocket.newInstance();
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return newConnectedSocket();
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return newConnectedSocket();
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return newConnectedSocket();
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return newConnectedSocket();
+    }
+
+    /**
+     * Creates and returns an already-connected {@link AFUNIXSocket}.
+     */
+    @VisibleForTesting
+    protected Socket newConnectedSocket() throws IOException {
+        var address = AFUNIXSocketAddress.of(socketPath);
+        return AFUNIXSocket.connectTo(address);
+    }
+}

--- a/src/main/java/org/kiwiproject/consul/UnixDomainSocketFactory.java
+++ b/src/main/java/org/kiwiproject/consul/UnixDomainSocketFactory.java
@@ -1,16 +1,14 @@
 package org.kiwiproject.consul;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.newsclub.net.unix.AFSocketFactory;
 import org.newsclub.net.unix.AFUNIXSocket;
 import org.newsclub.net.unix.AFUNIXSocketAddress;
 
 import javax.net.SocketFactory;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
-import java.net.SocketAddress;
 import java.nio.file.Path;
 
 /**
@@ -20,12 +18,12 @@ import java.nio.file.Path;
  * All {@code createSocket} overloads ignore the host and port arguments and
  * connect to the configured socket path.
  * <p>
- * The no-arg {@link #createSocket()} returns an unconnected socket wrapper
- * whose {@code connect()} method redirects to the Unix socket path. This is
- * required because OkHttp calls the no-arg {@code createSocket()} and then
- * calls {@code connect(InetSocketAddress)} separately; returning an
- * already-connected {@code AFUNIXSocket} there would cause junixsocket to
- * attempt (and fail) to map the TCP address via {@code AFSocketAddress.mapOrFail}.
+ * The no-arg {@link #createSocket()} delegates to
+ * {@link AFSocketFactory.FixedAddressSocketFactory}, which returns a real
+ * {@link AFUNIXSocket} configured via {@code forceConnectAddress}. This means
+ * OkHttp's standard {@code createSocket()} + {@code connect(InetSocketAddress)}
+ * flow transparently connects to the Unix domain socket path, and all socket
+ * options (including {@code setSoTimeout}) work natively on the underlying socket.
  * <p>
  * The overloads that accept a host/port return an already-connected socket
  * directly, since callers of those variants do not make a separate
@@ -50,70 +48,15 @@ public class UnixDomainSocketFactory extends SocketFactory {
     }
 
     /**
-     * Returns a socket wrapper backed by an unconnected {@link AFUNIXSocket}.
-     * The wrapper's {@code connect()} methods ignore the supplied address and
-     * always connect to {@link #socketPath}, so that OkHttp's standard
-     * {@code createSocket()} + {@code connect(InetSocketAddress)} flow works
-     * correctly with Unix domain sockets.
+     * Returns an unconnected {@link AFUNIXSocket} whose {@code connect()} methods
+     * ignore the supplied address and always connect to the configured socket path.
+     * This allows OkHttp's standard {@code createSocket()} +
+     * {@code connect(InetSocketAddress)} flow to work correctly with Unix domain sockets.
      */
     @Override
     public Socket createSocket() throws IOException {
-        var unixSocket = newAFUNIXSocket();
-        var unixAddress = AFUNIXSocketAddress.of(socketPath);
-        return new Socket() {
-            @Override
-            public void connect(SocketAddress endpoint) throws IOException {
-                unixSocket.connect(unixAddress);
-            }
-
-            @Override
-            public void connect(SocketAddress endpoint, int timeout) throws IOException {
-                unixSocket.connect(unixAddress, timeout);
-            }
-
-            @Override
-            public InputStream getInputStream() throws IOException {
-                return unixSocket.getInputStream();
-            }
-
-            @Override
-            public OutputStream getOutputStream() throws IOException {
-                return unixSocket.getOutputStream();
-            }
-
-            @Override
-            public boolean isConnected() {
-                return unixSocket.isConnected();
-            }
-
-            @Override
-            public boolean isClosed() {
-                return unixSocket.isClosed();
-            }
-
-            @Override
-            public boolean isInputShutdown() {
-                return unixSocket.isInputShutdown();
-            }
-
-            @Override
-            public boolean isOutputShutdown() {
-                return unixSocket.isOutputShutdown();
-            }
-
-            @Override
-            public synchronized void close() throws IOException {
-                unixSocket.close();
-            }
-        };
-    }
-
-    /**
-     * Creates a new, unconnected {@link AFUNIXSocket}.
-     */
-    @VisibleForTesting
-    protected AFUNIXSocket newAFUNIXSocket() throws IOException {
-        return AFUNIXSocket.newInstance();
+        return new AFSocketFactory.FixedAddressSocketFactory(AFUNIXSocketAddress.of(socketPath))
+                .createSocket();
     }
 
     @Override

--- a/src/test/java/org/kiwiproject/consul/ConsulTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulTest.java
@@ -32,6 +32,7 @@ import java.net.ConnectException;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.nio.file.Path;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
@@ -329,6 +330,86 @@ class ConsulTest {
 
             assertThatNullPointerException()
                     .isThrownBy(() -> consul.statusClient().getLeader());
+        }
+    }
+
+    @Nested
+    class WithUnixDomainSocket {
+
+        @Test
+        void shouldReturnBuilder_WhenGivenPath() {
+            var builder = Consul.builder();
+            assertThat(builder.withUnixDomainSocket(Path.of("/tmp/consul.sock"))).isSameAs(builder);
+        }
+
+        @Test
+        void shouldReturnBuilder_WhenGivenString() {
+            var builder = Consul.builder();
+            assertThat(builder.withUnixDomainSocket("/tmp/consul.sock")).isSameAs(builder);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = { "", "   ", "\t" })
+        void shouldRejectBlankPath(String socketPath) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> Consul.builder().withUnixDomainSocket(socketPath))
+                    .withMessage("socketPath must not be null or blank");
+        }
+
+        @Test
+        void shouldRejectNullStringPath() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> Consul.builder().withUnixDomainSocket((String) null))
+                    .withMessage("socketPath must not be null or blank");
+        }
+
+        @Test
+        void shouldThrowIllegalStateException_WhenBothUdsAndSslAreConfigured()
+                throws NoSuchAlgorithmException {
+            var builder = Consul.builder()
+                    .withUnixDomainSocket("/tmp/consul.sock")
+                    .withSslContext(SSLContext.getDefault());
+
+            assertThatExceptionOfType(IllegalStateException.class)
+                    .isThrownBy(builder::build)
+                    .withMessage("Cannot use a Unix domain socket with SSL/TLS; " +
+                            "configure withUnixDomainSocket or an SSL context, not both");
+        }
+
+        @Test
+        void shouldBuildSuccessfully_WhenOnlyUdsIsConfigured() {
+            var consul = Consul.builder()
+                    .withUnixDomainSocket("/tmp/consul.sock")
+                    .build();
+
+            assertThat(consul).isNotNull();
+        }
+    }
+
+    @Nested
+    class AddUnixDomainSocketFactory {
+
+        @Test
+        void shouldDoNothing_WhenSocketPathIsNull() {
+            var okHttpClientBuilder = new OkHttpClient.Builder();
+
+            Consul.Builder.addUnixDomainSocketFactory(null, okHttpClientBuilder);
+
+            var okHttpClient = okHttpClientBuilder.build();
+            assertThat(okHttpClient.socketFactory()).isNotInstanceOf(UnixDomainSocketFactory.class);
+            assertThat(okHttpClient.proxy()).isNull();
+        }
+
+        @Test
+        void shouldSetSocketFactoryAndNoProxy_WhenPathIsProvided() {
+            var okHttpClientBuilder = new OkHttpClient.Builder();
+            var socketPath = Path.of("/tmp/consul.sock");
+
+            Consul.Builder.addUnixDomainSocketFactory(socketPath, okHttpClientBuilder);
+
+            var okHttpClient = okHttpClientBuilder.build();
+            assertThat(okHttpClient.socketFactory()).isInstanceOf(UnixDomainSocketFactory.class);
+            assertThat(okHttpClient.proxy()).isEqualTo(java.net.Proxy.NO_PROXY);
         }
     }
 

--- a/src/test/java/org/kiwiproject/consul/ConsulTest.java
+++ b/src/test/java/org/kiwiproject/consul/ConsulTest.java
@@ -364,6 +364,13 @@ class ConsulTest {
         }
 
         @Test
+        void shouldRejectNullPath() {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> Consul.builder().withUnixDomainSocket((Path) null))
+                    .withMessage("socketPath must not be null");
+        }
+
+        @Test
         void shouldThrowIllegalStateException_WhenBothUdsAndSslAreConfigured()
                 throws NoSuchAlgorithmException {
             var builder = Consul.builder()

--- a/src/test/java/org/kiwiproject/consul/UnixDomainSocketFactoryTest.java
+++ b/src/test/java/org/kiwiproject/consul/UnixDomainSocketFactoryTest.java
@@ -1,18 +1,13 @@
 package org.kiwiproject.consul;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.newsclub.net.unix.AFUNIXSocket;
-import org.newsclub.net.unix.AFUNIXSocketAddress;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,112 +29,31 @@ class UnixDomainSocketFactoryTest {
 
     private static final Path TEST_SOCKET_PATH = Path.of("/tmp/test-consul.sock");
 
-    private AFUNIXSocket mockUnixSocket;
     private Socket mockConnectedSocket;
     private TestableUnixDomainSocketFactory factory;
 
     @BeforeEach
     void setUp() {
-        mockUnixSocket = mock(AFUNIXSocket.class);
         mockConnectedSocket = mock(Socket.class);
-        factory = new TestableUnixDomainSocketFactory(TEST_SOCKET_PATH, mockUnixSocket, mockConnectedSocket);
+        factory = new TestableUnixDomainSocketFactory(TEST_SOCKET_PATH, mockConnectedSocket);
     }
 
     /**
-     * Subclass that overrides the two protected seam methods so tests run without
+     * Subclass that overrides the protected seam method so tests run without
      * native junixsocket resources and without an actual socket file on disk.
      */
     static class TestableUnixDomainSocketFactory extends UnixDomainSocketFactory {
 
-        private final AFUNIXSocket mockUnixSocket;
         private final Socket mockConnectedSocket;
 
-        TestableUnixDomainSocketFactory(Path socketPath,
-                                        AFUNIXSocket mockUnixSocket,
-                                        Socket mockConnectedSocket) {
+        TestableUnixDomainSocketFactory(Path socketPath, Socket mockConnectedSocket) {
             super(socketPath);
-            this.mockUnixSocket = mockUnixSocket;
             this.mockConnectedSocket = mockConnectedSocket;
-        }
-
-        @Override
-        protected AFUNIXSocket newAFUNIXSocket() {
-            return mockUnixSocket;
         }
 
         @Override
         protected Socket newConnectedSocket() {
             return mockConnectedSocket;
-        }
-    }
-
-    @Nested
-    class CreateSocket_NoArgs {
-
-        private Socket wrapper;
-
-        @BeforeEach
-        void setUp() throws IOException {
-            wrapper = factory.createSocket();
-        }
-
-        @Test
-        void shouldReturnNonNullSocket() {
-            assertThat(wrapper).isNotNull();
-        }
-
-        @Test
-        void shouldDelegateConnect_ToUnixSocket() throws IOException {
-            wrapper.connect(new InetSocketAddress("localhost", 8500));
-            verify(mockUnixSocket).connect(any(AFUNIXSocketAddress.class));
-        }
-
-        @Test
-        void shouldDelegateConnectWithTimeout_ToUnixSocket() throws IOException {
-            wrapper.connect(new InetSocketAddress("localhost", 8500), 5_000);
-            verify(mockUnixSocket).connect(any(AFUNIXSocketAddress.class), eq(5_000));
-        }
-
-        @Test
-        void shouldDelegateGetInputStream() throws IOException {
-            wrapper.getInputStream();
-            verify(mockUnixSocket).getInputStream();
-        }
-
-        @Test
-        void shouldDelegateGetOutputStream() throws IOException {
-            wrapper.getOutputStream();
-            verify(mockUnixSocket).getOutputStream();
-        }
-
-        @Test
-        void shouldDelegateIsConnected() {
-            wrapper.isConnected();
-            verify(mockUnixSocket).isConnected();
-        }
-
-        @Test
-        void shouldDelegateIsClosed() {
-            wrapper.isClosed();
-            verify(mockUnixSocket).isClosed();
-        }
-
-        @Test
-        void shouldDelegateIsInputShutdown() {
-            wrapper.isInputShutdown();
-            verify(mockUnixSocket).isInputShutdown();
-        }
-
-        @Test
-        void shouldDelegateIsOutputShutdown() {
-            wrapper.isOutputShutdown();
-            verify(mockUnixSocket).isOutputShutdown();
-        }
-
-        @Test
-        void shouldDelegateClose() throws IOException {
-            wrapper.close();
-            verify(mockUnixSocket).close();
         }
     }
 
@@ -171,7 +85,7 @@ class UnixDomainSocketFactoryTest {
     }
 
     @Nested
-    class NewConnectedSocket {
+    class WithRealServer {
 
         private Path socketPath;
         private ServerSocketChannel serverChannel;
@@ -209,7 +123,16 @@ class UnixDomainSocketFactoryTest {
         }
 
         @Test
-        void shouldReturnConnectedSocket() throws IOException {
+        void shouldReturnConnectedSocket_WhenNoArgs() throws IOException {
+            var realFactory = new UnixDomainSocketFactory(socketPath);
+            try (var socket = realFactory.createSocket()) {
+                socket.connect(new InetSocketAddress("ignored-host", 0));
+                assertThat(socket.isConnected()).isTrue();
+            }
+        }
+
+        @Test
+        void shouldReturnConnectedSocket_WhenGivenHostAndPort() throws IOException {
             var realFactory = new UnixDomainSocketFactory(socketPath);
             try (var socket = realFactory.createSocket("ignored-host", 0)) {
                 assertThat(socket.isConnected()).isTrue();

--- a/src/test/java/org/kiwiproject/consul/UnixDomainSocketFactoryTest.java
+++ b/src/test/java/org/kiwiproject/consul/UnixDomainSocketFactoryTest.java
@@ -148,25 +148,25 @@ class UnixDomainSocketFactoryTest {
 
         @Test
         void shouldReturnConnectedSocket_WhenGivenHostAndPort() throws IOException {
-            assertThat(factory.createSocket("localhost", 8500)).isSameAs(mockConnectedSocket);
+            assertThat(factory.createSocket("ignored-host", 0)).isSameAs(mockConnectedSocket);
         }
 
         @Test
         void shouldReturnConnectedSocket_WhenGivenHostPortAndLocalAddress() throws IOException {
-            assertThat(factory.createSocket("localhost", 8500, InetAddress.getLoopbackAddress(), 0))
+            assertThat(factory.createSocket("ignored-host", 0, InetAddress.getLoopbackAddress(), 0))
                     .isSameAs(mockConnectedSocket);
         }
 
         @Test
         void shouldReturnConnectedSocket_WhenGivenInetAddressAndPort() throws IOException {
-            assertThat(factory.createSocket(InetAddress.getLoopbackAddress(), 8500))
+            assertThat(factory.createSocket(InetAddress.getLoopbackAddress(), 0))
                     .isSameAs(mockConnectedSocket);
         }
 
         @Test
         void shouldReturnConnectedSocket_WhenGivenTwoInetAddressesAndPorts() throws IOException {
             var addr = InetAddress.getLoopbackAddress();
-            assertThat(factory.createSocket(addr, 8500, addr, 0)).isSameAs(mockConnectedSocket);
+            assertThat(factory.createSocket(addr, 0, addr, 0)).isSameAs(mockConnectedSocket);
         }
     }
 
@@ -211,7 +211,7 @@ class UnixDomainSocketFactoryTest {
         @Test
         void shouldReturnConnectedSocket() throws IOException {
             var realFactory = new UnixDomainSocketFactory(socketPath);
-            try (var socket = realFactory.createSocket("localhost", 8500)) {
+            try (var socket = realFactory.createSocket("ignored-host", 0)) {
                 assertThat(socket.isConnected()).isTrue();
             }
         }

--- a/src/test/java/org/kiwiproject/consul/UnixDomainSocketFactoryTest.java
+++ b/src/test/java/org/kiwiproject/consul/UnixDomainSocketFactoryTest.java
@@ -6,21 +6,31 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.newsclub.net.unix.AFUNIXSocket;
 import org.newsclub.net.unix.AFUNIXSocketAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.StandardProtocolFamily;
+import java.net.UnixDomainSocketAddress;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.UUID;
 
 @DisplayName("UnixDomainSocketFactory")
 class UnixDomainSocketFactoryTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(UnixDomainSocketFactoryTest.class);
 
     private static final Path TEST_SOCKET_PATH = Path.of("/tmp/test-consul.sock");
 
@@ -157,6 +167,53 @@ class UnixDomainSocketFactoryTest {
         void shouldReturnConnectedSocket_WhenGivenTwoInetAddressesAndPorts() throws IOException {
             var addr = InetAddress.getLoopbackAddress();
             assertThat(factory.createSocket(addr, 8500, addr, 0)).isSameAs(mockConnectedSocket);
+        }
+    }
+
+    @Nested
+    class NewConnectedSocket {
+
+        private Path socketPath;
+        private ServerSocketChannel serverChannel;
+        private Thread acceptThread;
+
+        @BeforeEach
+        void setUp() throws IOException {
+            // Use /tmp directly — java.io.tmpdir on macOS expands to a long /var/folders/...
+            // path. Unix domain socket paths are limited to 104 bytes on macOS (the
+            // sockaddr_un sun_path field in sys/un.h) and 108 bytes on Linux.
+            socketPath = Path.of("/tmp", "consul-uds-" + UUID.randomUUID().toString().substring(0, 8) + ".sock");
+
+            serverChannel = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
+            serverChannel.bind(UnixDomainSocketAddress.of(socketPath));
+            LOG.info("Test server listening on: {}", socketPath);
+
+            acceptThread = new Thread(() -> {
+                try {
+                    while (!Thread.currentThread().isInterrupted()) {
+                        serverChannel.accept().close();
+                    }
+                } catch (IOException e) {
+                    // server channel closed — expected on teardown
+                }
+            });
+            acceptThread.setDaemon(true);
+            acceptThread.start();
+        }
+
+        @AfterEach
+        void tearDown() throws IOException {
+            acceptThread.interrupt();
+            serverChannel.close();
+            Files.deleteIfExists(socketPath);
+        }
+
+        @Test
+        void shouldReturnConnectedSocket() throws IOException {
+            var realFactory = new UnixDomainSocketFactory(socketPath);
+            try (var socket = realFactory.createSocket("localhost", 8500)) {
+                assertThat(socket.isConnected()).isTrue();
+            }
         }
     }
 }

--- a/src/test/java/org/kiwiproject/consul/UnixDomainSocketFactoryTest.java
+++ b/src/test/java/org/kiwiproject/consul/UnixDomainSocketFactoryTest.java
@@ -1,0 +1,162 @@
+package org.kiwiproject.consul;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.newsclub.net.unix.AFUNIXSocket;
+import org.newsclub.net.unix.AFUNIXSocketAddress;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.file.Path;
+
+@DisplayName("UnixDomainSocketFactory")
+class UnixDomainSocketFactoryTest {
+
+    private static final Path TEST_SOCKET_PATH = Path.of("/tmp/test-consul.sock");
+
+    private AFUNIXSocket mockUnixSocket;
+    private Socket mockConnectedSocket;
+    private TestableUnixDomainSocketFactory factory;
+
+    @BeforeEach
+    void setUp() {
+        mockUnixSocket = mock(AFUNIXSocket.class);
+        mockConnectedSocket = mock(Socket.class);
+        factory = new TestableUnixDomainSocketFactory(TEST_SOCKET_PATH, mockUnixSocket, mockConnectedSocket);
+    }
+
+    /**
+     * Subclass that overrides the two protected seam methods so tests run without
+     * native junixsocket resources and without an actual socket file on disk.
+     */
+    static class TestableUnixDomainSocketFactory extends UnixDomainSocketFactory {
+
+        private final AFUNIXSocket mockUnixSocket;
+        private final Socket mockConnectedSocket;
+
+        TestableUnixDomainSocketFactory(Path socketPath,
+                                        AFUNIXSocket mockUnixSocket,
+                                        Socket mockConnectedSocket) {
+            super(socketPath);
+            this.mockUnixSocket = mockUnixSocket;
+            this.mockConnectedSocket = mockConnectedSocket;
+        }
+
+        @Override
+        protected AFUNIXSocket newAFUNIXSocket() {
+            return mockUnixSocket;
+        }
+
+        @Override
+        protected Socket newConnectedSocket() {
+            return mockConnectedSocket;
+        }
+    }
+
+    @Nested
+    class CreateSocket_NoArgs {
+
+        private Socket wrapper;
+
+        @BeforeEach
+        void setUp() throws IOException {
+            wrapper = factory.createSocket();
+        }
+
+        @Test
+        void shouldReturnNonNullSocket() {
+            assertThat(wrapper).isNotNull();
+        }
+
+        @Test
+        void shouldDelegateConnect_ToUnixSocket() throws IOException {
+            wrapper.connect(new InetSocketAddress("localhost", 8500));
+            verify(mockUnixSocket).connect(any(AFUNIXSocketAddress.class));
+        }
+
+        @Test
+        void shouldDelegateConnectWithTimeout_ToUnixSocket() throws IOException {
+            wrapper.connect(new InetSocketAddress("localhost", 8500), 5_000);
+            verify(mockUnixSocket).connect(any(AFUNIXSocketAddress.class), eq(5_000));
+        }
+
+        @Test
+        void shouldDelegateGetInputStream() throws IOException {
+            wrapper.getInputStream();
+            verify(mockUnixSocket).getInputStream();
+        }
+
+        @Test
+        void shouldDelegateGetOutputStream() throws IOException {
+            wrapper.getOutputStream();
+            verify(mockUnixSocket).getOutputStream();
+        }
+
+        @Test
+        void shouldDelegateIsConnected() {
+            wrapper.isConnected();
+            verify(mockUnixSocket).isConnected();
+        }
+
+        @Test
+        void shouldDelegateIsClosed() {
+            wrapper.isClosed();
+            verify(mockUnixSocket).isClosed();
+        }
+
+        @Test
+        void shouldDelegateIsInputShutdown() {
+            wrapper.isInputShutdown();
+            verify(mockUnixSocket).isInputShutdown();
+        }
+
+        @Test
+        void shouldDelegateIsOutputShutdown() {
+            wrapper.isOutputShutdown();
+            verify(mockUnixSocket).isOutputShutdown();
+        }
+
+        @Test
+        void shouldDelegateClose() throws IOException {
+            wrapper.close();
+            verify(mockUnixSocket).close();
+        }
+    }
+
+    @Nested
+    class CreateSocket_WithHostAndPort {
+
+        @Test
+        void shouldReturnConnectedSocket_WhenGivenHostAndPort() throws IOException {
+            assertThat(factory.createSocket("localhost", 8500)).isSameAs(mockConnectedSocket);
+        }
+
+        @Test
+        void shouldReturnConnectedSocket_WhenGivenHostPortAndLocalAddress() throws IOException {
+            assertThat(factory.createSocket("localhost", 8500, InetAddress.getLoopbackAddress(), 0))
+                    .isSameAs(mockConnectedSocket);
+        }
+
+        @Test
+        void shouldReturnConnectedSocket_WhenGivenInetAddressAndPort() throws IOException {
+            assertThat(factory.createSocket(InetAddress.getLoopbackAddress(), 8500))
+                    .isSameAs(mockConnectedSocket);
+        }
+
+        @Test
+        void shouldReturnConnectedSocket_WhenGivenTwoInetAddressesAndPorts() throws IOException {
+            var addr = InetAddress.getLoopbackAddress();
+            assertThat(factory.createSocket(addr, 8500, addr, 0)).isSameAs(mockConnectedSocket);
+        }
+    }
+}


### PR DESCRIPTION
* Add unixSocketPath to Consul.
* Add junixsocket-core as an optional dependency, since Unix domain socket support is not required.
* Create UnixDomainSocketFactory that extends SocketFactory and provides the support for Unix domain sockets using the junixsocket-core library's AFUNIXSocket class.

Closes #551