### PR TITLE
Fix Base64 charset bug in serializer and deserializer

### DIFF
--- a/src/main/java/org/kiwiproject/consul/util/Base64EncodingDeserializer.java
+++ b/src/main/java/org/kiwiproject/consul/util/Base64EncodingDeserializer.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
 
@@ -22,7 +23,7 @@ public class Base64EncodingDeserializer extends JsonDeserializer<Optional<String
         String value = p.getValueAsString();
 
         if (StringUtils.isNotEmpty(value)) {
-            return Optional.of(new String(Base64.getDecoder().decode(value)));
+            return Optional.of(new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8));
         }
         return Optional.empty();
     }

--- a/src/main/java/org/kiwiproject/consul/util/Base64EncodingSerializer.java
+++ b/src/main/java/org/kiwiproject/consul/util/Base64EncodingSerializer.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.SerializerProvider;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Optional;
 
@@ -13,7 +14,7 @@ public class Base64EncodingSerializer extends JsonSerializer<Optional<String>> {
     @Override
     public void serialize(Optional<String> string, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
         if (string.isPresent()) {
-            jsonGenerator.writeString(Base64.getEncoder().encodeToString(string.get().getBytes()));
+            jsonGenerator.writeString(Base64.getEncoder().encodeToString(string.get().getBytes(StandardCharsets.UTF_8)));
         } else {
             jsonGenerator.writeNull();
         }

--- a/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
@@ -8,6 +8,7 @@ import org.kiwiproject.consul.model.event.Event;
 import org.kiwiproject.consul.model.event.ImmutableEvent;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 class Base64EncodingDeserializerTest {
@@ -20,7 +21,7 @@ class Base64EncodingDeserializerTest {
                 .lTime(1L)
                 .name("name")
                 .version(1)
-                .payload(Base64.getEncoder().encodeToString(value.getBytes()))
+                .payload(Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8)))
                 .build();
 
         String serializedEvent = Jackson.MAPPER.writeValueAsString(event);

--- a/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
@@ -51,7 +51,7 @@ class Base64EncodingDeserializerTest {
 
     @Test
     void shouldReturnEmpty_WhenPayloadIsNull() throws IOException {
-        var json = """
+        @Language("JSON") var json = """
                 {
                   "ID": "1",
                   "LTime": 1,

--- a/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
@@ -3,6 +3,7 @@ package org.kiwiproject.consul.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.commons.lang3.RandomStringUtils;
+import org.intellij.lang.annotations.Language;
 import org.junit.jupiter.api.Test;
 import org.kiwiproject.consul.model.event.Event;
 import org.kiwiproject.consul.model.event.ImmutableEvent;
@@ -28,5 +29,33 @@ class Base64EncodingDeserializerTest {
         Event deserializedEvent = Jackson.MAPPER.readValue(serializedEvent, Event.class);
 
         assertThat(deserializedEvent.getPayload()).contains(value);
+    }
+
+    @Test
+    void shouldReturnEmpty_WhenPayloadIsNull() throws IOException {
+        var json = """
+                {
+                  "ID": "1",
+                  "LTime": 1,
+                  "Name": "name",
+                  "Version": 1,
+                  "Payload": null
+                }""";
+        var event = Jackson.MAPPER.readValue(json, Event.class);
+        assertThat(event.getPayload()).isEmpty();
+    }
+
+    @Test
+    void shouldReturnEmpty_WhenPayloadIsEmptyString() throws IOException {
+        @Language("JSON") var json = """
+                {
+                  "ID": "1",
+                  "LTime": 1,
+                  "Name": "name",
+                  "Version": 1,
+                  "Payload": ""
+                }""";
+        var event = Jackson.MAPPER.readValue(json, Event.class);
+        assertThat(event.getPayload()).isEmpty();
     }
 }

--- a/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/Base64EncodingDeserializerTest.java
@@ -32,6 +32,24 @@ class Base64EncodingDeserializerTest {
     }
 
     @Test
+    void shouldDeserialize_WithNonAsciiCharacters() throws IOException {
+        var value = "café naïve éàü";
+        var encoded = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+        var event = ImmutableEvent.builder()
+                .id("1")
+                .lTime(1L)
+                .name("name")
+                .version(1)
+                .payload(encoded)
+                .build();
+
+        String serializedEvent = Jackson.MAPPER.writeValueAsString(event);
+        Event deserializedEvent = Jackson.MAPPER.readValue(serializedEvent, Event.class);
+
+        assertThat(deserializedEvent.getPayload()).contains(value);
+    }
+
+    @Test
     void shouldReturnEmpty_WhenPayloadIsNull() throws IOException {
         var json = """
                 {

--- a/src/test/java/org/kiwiproject/consul/util/Base64EncodingSerializerTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/Base64EncodingSerializerTest.java
@@ -1,0 +1,54 @@
+package org.kiwiproject.consul.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+import org.kiwiproject.consul.model.kv.ImmutableOperation;
+import org.kiwiproject.consul.model.kv.Operation;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+class Base64EncodingSerializerTest {
+
+    @Test
+    void shouldSerializePresent() throws IOException {
+        var value = RandomStringUtils.secure().nextAlphabetic(12);
+        var operation = ImmutableOperation.builder()
+                .verb("set")
+                .value(value)
+                .build();
+
+        String json = Jackson.MAPPER.writeValueAsString(operation);
+        Operation deserialized = Jackson.MAPPER.readValue(json, Operation.class);
+
+        assertThat(deserialized.value()).contains(value);
+    }
+
+    @Test
+    void shouldSerializeAsBase64() throws IOException {
+        var value = RandomStringUtils.secure().nextAlphabetic(12);
+        var operation = ImmutableOperation.builder()
+                .verb("set")
+                .value(value)
+                .build();
+
+        String json = Jackson.MAPPER.writeValueAsString(operation);
+        var expectedEncoded = Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+
+        assertThat(json).contains(expectedEncoded);
+    }
+
+    @Test
+    void shouldSerializeEmptyAsNull() throws IOException {
+        var operation = ImmutableOperation.builder()
+                .verb("set")
+                .build();
+
+        String json = Jackson.MAPPER.writeValueAsString(operation);
+
+        assertThat(json).contains("\"Value\":null");
+    }
+}

--- a/src/test/java/org/kiwiproject/consul/util/Base64EncodingSerializerTest.java
+++ b/src/test/java/org/kiwiproject/consul/util/Base64EncodingSerializerTest.java
@@ -42,6 +42,20 @@ class Base64EncodingSerializerTest {
     }
 
     @Test
+    void shouldSerializePresent_WithNonAsciiCharacters() throws IOException {
+        var value = "café naïve éàü";
+        var operation = ImmutableOperation.builder()
+                .verb("set")
+                .value(value)
+                .build();
+
+        String json = Jackson.MAPPER.writeValueAsString(operation);
+        Operation deserialized = Jackson.MAPPER.readValue(json, Operation.class);
+
+        assertThat(deserialized.value()).contains(value);
+    }
+
+    @Test
     void shouldSerializeEmptyAsNull() throws IOException {
         var operation = ImmutableOperation.builder()
                 .verb("set")


### PR DESCRIPTION
## Summary

- Explicitly use UTF-8 instead of the platform default charset in
  Base64EncodingSerializer and Base64EncodingDeserializer
- Prevents silent data corruption in environments where the default
  charset is not UTF-8 (e.g. certain Docker configs or Windows CI)

Closes #550

🤖 Generated with [Claude Code](https://claude.com/claude-code)