### PR TITLE
Remove redundant Sonar properties from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,8 +65,6 @@
 
         <!-- Sonar properties -->
         <sonar.projectKey>kiwiproject_consul-client</sonar.projectKey>
-        <sonar.organization>kiwiproject</sonar.organization>
-        <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <!-- Exclude Consul.java from duplication analysis because it contains deprecated inner classes
              (Consul.NetworkTimeoutConfig and its Builder) that intentionally duplicate the top-level
              NetworkTimeoutConfig class for backward compatibility. Remove this exclusion in 2.0.0


### PR DESCRIPTION
Remove the redundant sonar.organization and sonar.host.url properties from pom.xml. These properties are already defined in kiwi-parent and do not need to be redefined here.