### PR TITLE
Run Sonar analysis on Java 21 instead of Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
       # Cache all the things
       - name: Cache SonarCloud packages
         uses: actions/cache@v5
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java-version == '17' && matrix.consul-version == '1.22' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java-version == '21' && matrix.consul-version == '1.22' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
@@ -70,16 +70,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests except on JDK 17 and Consul 1.22 (Sonar runs tests and analysis on JDK 17 / Consul 1.22)
+      # Run tests except on JDK 21 and Consul 1.22 (Sonar runs tests and analysis on JDK 21 / Consul 1.22)
       - name: Run tests
-        if: ${{ !(matrix.java-version == '17' && matrix.consul-version == '1.22') }}
+        if: ${{ !(matrix.java-version == '21' && matrix.consul-version == '1.22') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 17 / Consul 1.22 only)
+      # Run Sonar Analysis (on Java version 21 / Consul 1.22 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java-version == '17' && matrix.consul-version == '1.22' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java-version == '21' && matrix.consul-version == '1.22' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
SonarQube Cloud is ending support for running the scanner on Java 17 in July 2026. Switch the Sonar analysis step to run on Java 21.