### PR TITLE
fix: pre-verify events exist synchronously before testing async listEvents

### DIFF
--- a/src/itest/java/org/kiwiproject/consul/EventClientITest.java
+++ b/src/itest/java/org/kiwiproject/consul/EventClientITest.java
@@ -115,6 +115,12 @@ class EventClientITest extends BaseIntegrationTest {
                 .describedAs("Precondition: Event IDs should not be empty")
                 .isNotEmpty();
 
+        // Confirm all events are visible synchronously before exercising the async path.
+        // The async callback fires once; if Consul hasn't indexed all events yet that
+        // response is frozen with an incomplete set and the assertion can never recover.
+        awaitAtMost2s().untilAsserted(() ->
+                assertThat(getEventIds(eventClient.listEvents())).containsAll(eventIds));
+
         var callback = new TestEventResponseCallback();
         eventClient.listEvents(callback);
 
@@ -132,6 +138,12 @@ class EventClientITest extends BaseIntegrationTest {
         assertThat(eventIds)
                 .describedAs("Precondition: Event IDs should not be empty")
                 .isNotEmpty();
+
+        // Confirm all events are visible synchronously before exercising the async path.
+        // The async callback fires once; if Consul hasn't indexed all events yet that
+        // response is frozen with an incomplete set and the assertion can never recover.
+        awaitAtMost2s().untilAsserted(() ->
+                assertThat(getEventIds(eventClient.listEvents())).containsAll(eventIds));
 
         var callback = new TestEventResponseCallback();
         eventClient.listEvents(Options.BLANK_QUERY_OPTIONS, callback);


### PR DESCRIPTION
The async `listEvents(callback)` fires a single HTTP request and invokes `onComplete` exactly once. If Consul hasn't indexed the last-fired event by the time that response arrives, the callback's accumulated ID set is frozen with an incomplete set — the awaitility loop retries the assertion but the underlying data never changes, causing intermittent CI failures.

The pattern in the error output was consistent: always the *last* event ID was missing, which points to a race between the final `fireEvent` PUT returning and the event appearing in the `GET /v1/event/list` response.

The fix adds a synchronous pre-check in both affected tests using the blocking `listEvents()` to confirm all event IDs are visible in Consul before exercising the async path. Once events are confirmed present they won't disappear, so the subsequent async call is guaranteed to return a complete set.

Closes #554