### PR TITLE
Add Consul version 2.0 to build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,16 +73,16 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V compile
 
-      # Run tests except on JDK 21 and Consul 1.22 (Sonar runs tests and analysis on JDK 21 / Consul 1.22)
+      # Run tests except on JDK 21 and Consul 2.0 (Sonar runs tests and analysis on JDK 21 / Consul 2.0)
       - name: Run tests
-        if: ${{ !(matrix.java-version == '21' && matrix.consul-version == '1.22') }}
+        if: ${{ !(matrix.java-version == '21' && matrix.consul-version == '2.0') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
         run: mvn -B -V verify
 
-      # Run Sonar Analysis (on Java version 21 / Consul 1.22 only)
+      # Run Sonar Analysis (on Java version 21 / Consul 2.0 only)
       - name: Analyze with SonarCloud
-        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java-version == '21' && matrix.consul-version == '1.22' }}
+        if: ${{ env.SONAR_TOKEN != null && env.SONAR_TOKEN != '' && matrix.java-version == '21' && matrix.consul-version == '2.0' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         java-version: [ '17', '21', '25' ]
         # Need to quote versions ending in 0, otherwise they're truncated
         # such that 1.20 becomes 1.2. For correctness and consistency, quote everything.
-        consul-version: [ '1.21', '1.22', '2.0.1' ]
+        consul-version: [ '1.21', '1.22', '2.0' ]
 
         # Only test against one Consul version when using JDK 21 and 25. If they
         # all worked with JDK 17, it's probably good enough to only test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,11 +27,11 @@ jobs:
           - java-version: '21'
             consul-version: '1.21'
           - java-version: '21'
-            consul-version: '2.0.1'
+            consul-version: '1.22'
           - java-version: '25'
             consul-version: '1.21'
           - java-version: '25'
-            consul-version: '2.0.1'
+            consul-version: '1.22'
 
     env:
       CONSUL_IMAGE_VERSION: ${{ matrix.consul-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
         java-version: [ '17', '21', '25' ]
         # Need to quote versions ending in 0, otherwise they're truncated
         # such that 1.20 becomes 1.2. For correctness and consistency, quote everything.
-        consul-version: [ '1.21', '1.22' ]
+        consul-version: [ '1.21', '1.22', '2.0.1' ]
 
         # Only test against one Consul version when using JDK 21 and 25. If they
         # all worked with JDK 17, it's probably good enough to only test
@@ -26,8 +26,12 @@ jobs:
         exclude:
           - java-version: '21'
             consul-version: '1.21'
+          - java-version: '21'
+            consul-version: '2.0.1'
           - java-version: '25'
             consul-version: '1.21'
+          - java-version: '25'
+            consul-version: '2.0.1'
 
     env:
       CONSUL_IMAGE_VERSION: ${{ matrix.consul-version }}


### PR DESCRIPTION
Add consul 2.0 to the build matrix. This will use the latest 2.0.x version.

Only test against 2.0 for JDK 21 and 25. We test against all versions (at present 1.21, 1.22, and 2.0) in JDK 17.